### PR TITLE
Fix frontend Docker build (clean deps install)

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.vite
+npm-debug.log
+Dockerfile

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,9 +1,20 @@
 FROM node:20 AS build
 WORKDIR /app
+
+# copy package files first (better cache + clean install)
+COPY package*.json ./
+
+# install INCLUDING devDependencies (tsc lives there)
+RUN npm ci
+
+# now copy the rest of the app
 COPY . .
-RUN npm install
+
+# build
 RUN npm run build
+
 
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Fixes frontend Docker build by ensuring dev dependencies (TypeScript/tsc) are installed inside the build stage and improving layer caching. This resolves the tsc not found error so npm run build completes and the Vite app is correctly served via Nginx.