### PR TITLE
Task(CP-58): Added JaCoCo Tests In Comments For PRs

### DIFF
--- a/.github/workflows/pr-coverage.yml
+++ b/.github/workflows/pr-coverage.yml
@@ -1,0 +1,75 @@
+name: PR Coverage
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test-and-coverage:
+    runs-on: ubuntu-latest
+
+    # Allow the workflow to post/update comments on the PR
+    permissions:
+      contents: read
+      pull-requests: write
+
+    env:
+      # Adjust these as needed for your project
+      MIN_COVERAGE_OVERALL: 90
+      MIN_COVERAGE_CHANGED: 90
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      # Run tests + JaCoCo report for the backend module
+      - name: Run tests with JaCoCo (backend)
+        working-directory: ./backend
+        run: |
+          chmod +x gradlew
+          ./gradlew test jacocoTestReport
+
+      # Upload HTML reports as build artifacts for manual inspection (optional but nice)
+      - name: Upload JaCoCo HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-html-report
+          path: backend/build/jacocoHtml/
+
+      - name: Upload test report HTML
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-test-report
+          path: backend/build/reports/tests/test/
+
+      # Create or update a PR comment with overall + changed-files coverage
+      - name: JaCoCo Report to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.7.2
+        with:
+          # JaCoCo XML report produced by Gradle in your backend module
+          paths: |
+            ${{ github.workspace }}/backend/build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: ${{ env.MIN_COVERAGE_OVERALL }}
+          min-coverage-changed-files: ${{ env.MIN_COVERAGE_CHANGED }}
+          title: 'Code Coverage'
+          update-comment: true
+          comment-type: pr_comment
+
+      # Explicitly fail the job if coverage is below thresholds
+      - name: Fail if coverage below thresholds
+        if: >
+          steps.jacoco.outputs.coverage-overall < env.MIN_COVERAGE_OVERALL ||
+          steps.jacoco.outputs.coverage-changed-files < env.MIN_COVERAGE_CHANGED
+        run: |
+          echo "Coverage below threshold:"
+          echo "  overall: ${{ steps.jacoco.outputs.coverage-overall }}% (min ${{ env.MIN_COVERAGE_OVERALL }}%)"
+          echo "  changed: ${{ steps.jacoco.outputs.coverage-changed-files }}% (min ${{ env.MIN_COVERAGE_CHANGED }}%)"
+          exit 1


### PR DESCRIPTION
Set up a GitHub Actions workflow that automatically runs unit tests with JaCoCo, generates coverage reports, and posts a coverage summary directly on each Pull Request. The workflow must display overall project coverage, coverage for changed files, and highlight any newly uncovered lines introduced by the PR. Coverage thresholds should be configurable, and the workflow must fail when coverage falls below the required minimum. The final workflow file should be committed to .github/workflows and integrated with GitHub’s branch protection rules.