### PR TITLE
Task(CP-58): Add JaCoCo Coverage Reports In Comments For PRs

### DIFF
--- a/.github/workflows/pr-coverage.yml
+++ b/.github/workflows/pr-coverage.yml
@@ -35,7 +35,7 @@ jobs:
           chmod +x gradlew
           ./gradlew test jacocoTestReport
 
-      # Upload HTML reports as build artifacts for manual inspection
+      # Upload HTML reports as build artifacts for manual inspection (optional but nice)
       - name: Upload JaCoCo HTML report
         uses: actions/upload-artifact@v4
         with:
@@ -47,34 +47,6 @@ jobs:
         with:
           name: junit-test-report
           path: backend/build/reports/tests/test/
-
-      # Extra comment with direct links to the artifacts page for this run
-      - name: Comment with report links
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}#artifacts`;
-
-            const body = [
-              '🧪 **Test & Coverage Reports (HTML)**',
-              '',
-              `- [JaCoCo HTML report](${runUrl})`,
-              `- [JUnit test report](${runUrl})`,
-              '',
-              '_In the run page, click the artifacts named:_',
-              '- `jacoco-html-report`',
-              '- `junit-test-report`'
-            ].join('\n');
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              body
-            });
 
       # Create or update a PR comment with overall + changed-files coverage
       - name: JaCoCo Report to PR
@@ -90,6 +62,58 @@ jobs:
           title: 'Code Coverage'
           update-comment: true
           comment-type: pr_comment
+
+      # Append HTML report links *inside the same coverage comment*
+      - name: Append HTML report links to coverage comment
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}#artifacts`;
+
+            // Get all comments on the PR
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            // Find the coverage comment created by madrapps/jacoco-report
+            const coverageComment = comments
+              .slice() // shallow copy
+              .reverse() // start from newest
+              .find(c =>
+                c.user?.type === 'Bot' &&
+                c.body &&
+                c.body.includes('Code Coverage')
+              );
+
+            if (!coverageComment) {
+              console.log('No coverage comment found to update');
+              return;
+            }
+
+            const linksSection = [
+              '',
+              '---',
+              '🧪 **Test & Coverage Reports (HTML)**',
+              '',
+              `- [JaCoCo HTML report](${runUrl})`,
+              `- [JUnit test report](${runUrl})`,
+              '',
+              '_Open the Action run → scroll to **Artifacts** → download the ZIPs and open `index.html` locally._'
+            ].join('\n');
+
+            await github.rest.issues.updateComment({
+              owner,
+              repo,
+              comment_id: coverageComment.id,
+              body: coverageComment.body + linksSection,
+            });
 
       # Explicitly fail the job if coverage is below thresholds
       - name: Fail if coverage below thresholds


### PR DESCRIPTION
Set up a GitHub Actions workflow that automatically runs unit tests with JaCoCo, generates coverage reports, and posts a coverage summary directly on each Pull Request. The workflow must display overall project coverage, coverage for changed files, and highlight any newly uncovered lines introduced by the PR. Coverage thresholds should be configurable, and the workflow must fail when coverage falls below the required minimum. The final workflow file should be committed to .github/workflows and integrated with GitHub’s branch protection rules.