### PR TITLE
Feat(CP-82): Added Reschedule button before cancelling

### DIFF
--- a/frontend/src/features/appointments/components/AppointmentDetailModal.tsx
+++ b/frontend/src/features/appointments/components/AppointmentDetailModal.tsx
@@ -489,6 +489,18 @@ export function AppointmentDetailModal({ isOpen, onClose, appointment, existingA
                         </div>
                     )}
 
+                    {/* Reschedule Action (CONFIRMED or PROPOSED, not cancelled/declined, not already in reschedule/decline/cancel mode) */}
+                    {appointment &&
+                        (appointment.status === 'CONFIRMED' || (appointment.status === 'PROPOSED' && appointment.initiatedBy === myRole)) &&
+                        !isCancelled && !isDeclineOpen && !isRescheduleOpen && !isCancelOpen && (
+                            <div className="pt-4">
+                                <Button variant="outline" className="w-full" onClick={openReschedule}>
+                                    <CalendarClock className="w-4 h-4 mr-2" />
+                                    {t('reschedule', 'Reschedule')}
+                                </Button>
+                            </div>
+                    )}
+
                     {/* Cancel Action (CONFIRMED or PROPOSED + ME) */}
                     {canCancel && !isCancelOpen && !isRescheduleOpen && !isDeclineOpen && (
                         <div className="pt-4 flex flex-col gap-3">


### PR DESCRIPTION
Adds a "Reschedule" button for confirmed and proposed appointments, allowing brokers and clients to propose a new time without cancelling first. Keeps existing cancel-then-reschedule flow for cancelled/declined appointments. Improves user experience for appointment management.