### PR TITLE
Feat(CP-83): Borker View Appointments From Clients

### DIFF
--- a/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentService.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentService.java
@@ -19,6 +19,13 @@ public interface AppointmentService {
 
         /**
          * Get all appointments for a client.
+         *
+         * @param clientId the public identifier of the client whose appointments are requested
+         * @param requesterId the identifier of the authenticated requester, used to enforce access
+         *                   control and ensure only authorized users can view the client's appointments
+         * @param requesterEmail the email of the authenticated requester, used to support additional
+         *                      access control checks or auditing as part of the filtering logic
+         * @return a list of appointments the requester is authorized to view for the given client
          */
         List<AppointmentResponseDTO> getAppointmentsForClient(UUID clientId, UUID requesterId, String requesterEmail);
 
@@ -32,7 +39,7 @@ public interface AppointmentService {
          * Get appointments for a client within a date range.
          */
         List<AppointmentResponseDTO> getAppointmentsForClientByDateRange(
-                        UUID clientId, LocalDateTime from, LocalDateTime to);
+                        UUID clientId, LocalDateTime from, LocalDateTime to, UUID requesterId, String requesterEmail);
 
         /**
          * Get appointments for a broker with specific status.
@@ -44,7 +51,7 @@ public interface AppointmentService {
          * Get appointments for a client with specific status.
          */
         List<AppointmentResponseDTO> getAppointmentsForClientByStatus(
-                        UUID clientId, AppointmentStatus status);
+                        UUID clientId, AppointmentStatus status, UUID requesterId, String requesterEmail);
 
         /**
          * Get appointments for a broker within a date range and with specific status.
@@ -56,7 +63,7 @@ public interface AppointmentService {
          * Get appointments for a client within a date range and with specific status.
          */
         List<AppointmentResponseDTO> getAppointmentsForClientByDateRangeAndStatus(
-                        UUID clientId, LocalDateTime from, LocalDateTime to, AppointmentStatus status);
+                        UUID clientId, LocalDateTime from, LocalDateTime to, AppointmentStatus status, UUID requesterId, String requesterEmail);
 
         /**
          * Get appointments for a specific transaction.

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentService.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentService.java
@@ -20,7 +20,7 @@ public interface AppointmentService {
         /**
          * Get all appointments for a client.
          */
-        List<AppointmentResponseDTO> getAppointmentsForClient(UUID clientId);
+        List<AppointmentResponseDTO> getAppointmentsForClient(UUID clientId, UUID requesterId, String requesterEmail);
 
         /**
          * Get appointments for a broker within a date range.

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImpl.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImpl.java
@@ -32,15 +32,18 @@ public class AppointmentServiceImpl implements AppointmentService {
         private final UserAccountRepository userAccountRepository;
         private final TransactionRepository transactionRepository;
         private final com.example.courtierprobackend.audit.appointment_audit.businesslayer.AppointmentAuditService appointmentAuditService;
+        private final com.example.courtierprobackend.transactions.datalayer.repositories.TransactionParticipantRepository transactionParticipantRepository;
 
         public AppointmentServiceImpl(AppointmentRepository appointmentRepository,
                         UserAccountRepository userAccountRepository,
                         TransactionRepository transactionRepository,
-                        com.example.courtierprobackend.audit.appointment_audit.businesslayer.AppointmentAuditService appointmentAuditService) {
+                        com.example.courtierprobackend.audit.appointment_audit.businesslayer.AppointmentAuditService appointmentAuditService,
+                        com.example.courtierprobackend.transactions.datalayer.repositories.TransactionParticipantRepository transactionParticipantRepository) {
                 this.appointmentRepository = appointmentRepository;
                 this.userAccountRepository = userAccountRepository;
                 this.transactionRepository = transactionRepository;
                 this.appointmentAuditService = appointmentAuditService;
+                this.transactionParticipantRepository = transactionParticipantRepository;
         }
 
         @Override
@@ -51,10 +54,24 @@ public class AppointmentServiceImpl implements AppointmentService {
         }
 
         @Override
-        public List<AppointmentResponseDTO> getAppointmentsForClient(UUID clientId) {
-                List<Appointment> appointments = appointmentRepository
-                                .findByClientIdAndDeletedAtIsNullOrderByFromDateTimeAsc(clientId);
-                return mapToDTOs(appointments);
+        public List<AppointmentResponseDTO> getAppointmentsForClient(UUID clientId, UUID requesterId, String requesterEmail) {
+                List<Appointment> allAppointments = appointmentRepository
+                        .findByClientIdAndDeletedAtIsNullOrderByFromDateTimeAsc(clientId);
+                final UUID finalRequesterId = requesterId;
+                final String finalRequesterEmail = requesterEmail;
+                List<Appointment> filtered = allAppointments.stream().filter(apt -> {
+                        if (finalRequesterId == null) return false;
+                        if (apt.getBrokerId() != null && apt.getBrokerId().equals(finalRequesterId)) return true;
+                        if (apt.getClientId() != null && apt.getClientId().equals(finalRequesterId)) return true;
+                        if (apt.getTransactionId() != null) {
+                                var participants = transactionParticipantRepository.findByTransactionId(apt.getTransactionId());
+                                return participants.stream().anyMatch(p ->
+                                                (p.getUserId() != null && p.getUserId().equals(finalRequesterId)) || (finalRequesterEmail != null && p.getEmail() != null && finalRequesterEmail.equalsIgnoreCase(p.getEmail()))
+                                );
+                        }
+                        return false;
+                }).collect(java.util.stream.Collectors.toList());
+                return mapToDTOs(filtered);
         }
 
         @Override

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImpl.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImpl.java
@@ -84,10 +84,24 @@ public class AppointmentServiceImpl implements AppointmentService {
 
         @Override
         public List<AppointmentResponseDTO> getAppointmentsForClientByDateRange(
-                        UUID clientId, LocalDateTime from, LocalDateTime to) {
+                        UUID clientId, LocalDateTime from, LocalDateTime to, UUID requesterId, String requesterEmail) {
                 List<Appointment> appointments = appointmentRepository
                                 .findByClientIdAndDateRange(clientId, from, to);
-                return mapToDTOs(appointments);
+                final UUID finalRequesterId = requesterId;
+                final String finalRequesterEmail = requesterEmail;
+                List<Appointment> filtered = appointments.stream().filter(apt -> {
+                        if (finalRequesterId == null) return false;
+                        if (apt.getBrokerId() != null && apt.getBrokerId().equals(finalRequesterId)) return true;
+                        if (apt.getClientId() != null && apt.getClientId().equals(finalRequesterId)) return true;
+                        if (apt.getTransactionId() != null) {
+                                var participants = transactionParticipantRepository.findByTransactionId(apt.getTransactionId());
+                                return participants.stream().anyMatch(p ->
+                                                (p.getUserId() != null && p.getUserId().equals(finalRequesterId)) || (finalRequesterEmail != null && p.getEmail() != null && finalRequesterEmail.equalsIgnoreCase(p.getEmail()))
+                                );
+                        }
+                        return false;
+                }).collect(java.util.stream.Collectors.toList());
+                return mapToDTOs(filtered);
         }
 
         @Override
@@ -100,10 +114,24 @@ public class AppointmentServiceImpl implements AppointmentService {
 
         @Override
         public List<AppointmentResponseDTO> getAppointmentsForClientByStatus(
-                        UUID clientId, AppointmentStatus status) {
+                        UUID clientId, AppointmentStatus status, UUID requesterId, String requesterEmail) {
                 List<Appointment> appointments = appointmentRepository
                                 .findByClientIdAndStatusAndDeletedAtIsNullOrderByFromDateTimeAsc(clientId, status);
-                return mapToDTOs(appointments);
+                final UUID finalRequesterId = requesterId;
+                final String finalRequesterEmail = requesterEmail;
+                List<Appointment> filtered = appointments.stream().filter(apt -> {
+                        if (finalRequesterId == null) return false;
+                        if (apt.getBrokerId() != null && apt.getBrokerId().equals(finalRequesterId)) return true;
+                        if (apt.getClientId() != null && apt.getClientId().equals(finalRequesterId)) return true;
+                        if (apt.getTransactionId() != null) {
+                                var participants = transactionParticipantRepository.findByTransactionId(apt.getTransactionId());
+                                return participants.stream().anyMatch(p ->
+                                                (p.getUserId() != null && p.getUserId().equals(finalRequesterId)) || (finalRequesterEmail != null && p.getEmail() != null && finalRequesterEmail.equalsIgnoreCase(p.getEmail()))
+                                );
+                        }
+                        return false;
+                }).collect(java.util.stream.Collectors.toList());
+                return mapToDTOs(filtered);
         }
 
         @Override
@@ -116,10 +144,24 @@ public class AppointmentServiceImpl implements AppointmentService {
 
         @Override
         public List<AppointmentResponseDTO> getAppointmentsForClientByDateRangeAndStatus(
-                        UUID clientId, LocalDateTime from, LocalDateTime to, AppointmentStatus status) {
+                        UUID clientId, LocalDateTime from, LocalDateTime to, AppointmentStatus status, UUID requesterId, String requesterEmail) {
                 List<Appointment> appointments = appointmentRepository
                                 .findByClientIdAndDateRangeAndStatus(clientId, from, to, status);
-                return mapToDTOs(appointments);
+                final UUID finalRequesterId = requesterId;
+                final String finalRequesterEmail = requesterEmail;
+                List<Appointment> filtered = appointments.stream().filter(apt -> {
+                        if (finalRequesterId == null) return false;
+                        if (apt.getBrokerId() != null && apt.getBrokerId().equals(finalRequesterId)) return true;
+                        if (apt.getClientId() != null && apt.getClientId().equals(finalRequesterId)) return true;
+                        if (apt.getTransactionId() != null) {
+                                var participants = transactionParticipantRepository.findByTransactionId(apt.getTransactionId());
+                                return participants.stream().anyMatch(p ->
+                                                (p.getUserId() != null && p.getUserId().equals(finalRequesterId)) || (finalRequesterEmail != null && p.getEmail() != null && finalRequesterEmail.equalsIgnoreCase(p.getEmail()))
+                                );
+                        }
+                        return false;
+                }).collect(java.util.stream.Collectors.toList());
+                return mapToDTOs(filtered);
         }
 
         @Override

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentController.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentController.java
@@ -53,21 +53,28 @@ public class AppointmentController {
 
         List<AppointmentResponseDTO> appointments;
 
+        String requesterEmail = null;
+        if (jwt != null) {
+            Object emailClaim = jwt.getClaims().get("email");
+            if (emailClaim instanceof String) {
+                requesterEmail = (String) emailClaim;
+            }
+        }
         if (from != null && to != null && status != null) {
             // Filter by date range AND status
             appointments = isBroker
                     ? appointmentService.getAppointmentsForBrokerByDateRangeAndStatus(userId, from, to, status)
-                    : appointmentService.getAppointmentsForClientByDateRangeAndStatus(userId, from, to, status);
+                    : appointmentService.getAppointmentsForClientByDateRangeAndStatus(userId, from, to, status, userId, requesterEmail);
         } else if (from != null && to != null) {
             // Filter by date range
             appointments = isBroker
                     ? appointmentService.getAppointmentsForBrokerByDateRange(userId, from, to)
-                    : appointmentService.getAppointmentsForClientByDateRange(userId, from, to);
+                    : appointmentService.getAppointmentsForClientByDateRange(userId, from, to, userId, requesterEmail);
         } else if (status != null) {
             // Filter by status
             appointments = isBroker
                     ? appointmentService.getAppointmentsForBrokerByStatus(userId, status)
-                    : appointmentService.getAppointmentsForClientByStatus(userId, status);
+                    : appointmentService.getAppointmentsForClientByStatus(userId, status, userId, requesterEmail);
         } else {
             // Get all appointments
             appointments = isBroker
@@ -177,6 +184,12 @@ public class AppointmentController {
         UUID requesterId = UserContextUtils.resolveUserId(request, brokerHeader);
         // If you have a way to get the email, set it here. Otherwise, pass null for now.
         String requesterEmail = null;
+        if (jwt != null) {
+            Object emailClaim = jwt.getClaims().get("email");
+            if (emailClaim instanceof String) {
+                requesterEmail = (String) emailClaim;
+            }
+        }
         List<AppointmentResponseDTO> appointments = appointmentService.getAppointmentsForClient(clientId, requesterId, requesterEmail);
         return ResponseEntity.ok(appointments);
     }

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentController.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentController.java
@@ -71,8 +71,8 @@ public class AppointmentController {
         } else {
             // Get all appointments
             appointments = isBroker
-                    ? appointmentService.getAppointmentsForBroker(userId)
-                    : appointmentService.getAppointmentsForClient(userId);
+                ? appointmentService.getAppointmentsForBroker(userId)
+                : appointmentService.getAppointmentsForClient(userId, userId, null);
         }
 
         return ResponseEntity.ok(appointments);
@@ -165,5 +165,19 @@ public class AppointmentController {
                 userId);
 
         return ResponseEntity.ok(updatedAppointment);
+    }
+
+    @GetMapping("/client/{clientId}")
+    @PreAuthorize("hasAnyRole('BROKER', 'ADMIN')")
+    public ResponseEntity<List<AppointmentResponseDTO>> getAppointmentsForClient(
+            @PathVariable UUID clientId,
+            @RequestHeader(value = "x-broker-id", required = false) String brokerHeader,
+            @AuthenticationPrincipal Jwt jwt,
+            HttpServletRequest request) {
+        UUID requesterId = UserContextUtils.resolveUserId(request, brokerHeader);
+        // If you have a way to get the email, set it here. Otherwise, pass null for now.
+        String requesterEmail = null;
+        List<AppointmentResponseDTO> appointments = appointmentService.getAppointmentsForClient(clientId, requesterId, requesterEmail);
+        return ResponseEntity.ok(appointments);
     }
 }

--- a/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImplAccessControlTest.java
+++ b/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImplAccessControlTest.java
@@ -1,0 +1,78 @@
+package com.example.courtierprobackend.appointments.businesslayer;
+
+import com.example.courtierprobackend.appointments.datalayer.Appointment;
+import com.example.courtierprobackend.appointments.datalayer.AppointmentRepository;
+import com.example.courtierprobackend.transactions.datalayer.TransactionParticipant;
+import com.example.courtierprobackend.transactions.datalayer.repositories.TransactionParticipantRepository;
+import com.example.courtierprobackend.user.dataaccesslayer.UserAccountRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class AppointmentServiceImplAccessControlTest {
+    @Mock
+    private AppointmentRepository appointmentRepository;
+    @Mock
+    private UserAccountRepository userAccountRepository;
+    @Mock
+    private com.example.courtierprobackend.transactions.datalayer.repositories.TransactionRepository transactionRepository;
+    @Mock
+    private com.example.courtierprobackend.audit.appointment_audit.businesslayer.AppointmentAuditService appointmentAuditService;
+    @Mock
+    private TransactionParticipantRepository transactionParticipantRepository;
+
+    private AppointmentServiceImpl appointmentService;
+    private UUID clientId;
+    private UUID brokerId;
+    private UUID coBrokerId;
+    private UUID transactionId;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        appointmentService = new AppointmentServiceImpl(
+                appointmentRepository,
+                userAccountRepository,
+                transactionRepository,
+                appointmentAuditService,
+                transactionParticipantRepository
+        );
+        clientId = UUID.randomUUID();
+        brokerId = UUID.randomUUID();
+        coBrokerId = UUID.randomUUID();
+        transactionId = UUID.randomUUID();
+    }
+
+    @Test
+    void getAppointmentsForClient_filtersByCoBrokerAccess() {
+        Appointment apt = new Appointment();
+        apt.setAppointmentId(UUID.randomUUID());
+        apt.setTransactionId(transactionId);
+        apt.setBrokerId(brokerId);
+        apt.setClientId(clientId);
+        when(appointmentRepository.findByClientIdAndDeletedAtIsNullOrderByFromDateTimeAsc(clientId))
+                .thenReturn(List.of(apt));
+        TransactionParticipant coBroker = new TransactionParticipant();
+        coBroker.setUserId(coBrokerId);
+        coBroker.setTransactionId(transactionId);
+        coBroker.setRole(com.example.courtierprobackend.transactions.datalayer.enums.ParticipantRole.CO_BROKER);
+        when(transactionParticipantRepository.findByTransactionId(transactionId)).thenReturn(List.of(coBroker));
+        // Simulate static context for UserContextUtils
+        // (You may need to use PowerMockito or similar for static mocking in real code)
+        // For this example, assume the filtering logic is testable directly.
+        // Act
+        List<Appointment> appointments = appointmentRepository.findByClientIdAndDeletedAtIsNullOrderByFromDateTimeAsc(clientId);
+        List<TransactionParticipant> participants = transactionParticipantRepository.findByTransactionId(transactionId);
+        boolean coBrokerHasAccess = participants.stream().anyMatch(p -> p.getUserId().equals(coBrokerId));
+        // Assert
+        assertThat(appointments).hasSize(1);
+        assertThat(coBrokerHasAccess).isTrue();
+    }
+}

--- a/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImplAccessControlTest.java
+++ b/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImplAccessControlTest.java
@@ -1,68 +1,10 @@
-    @Test
-    void getAppointmentsForClientByDateRange_filtersByCoBrokerAccess() {
-        Appointment apt = new Appointment();
-        apt.setAppointmentId(UUID.randomUUID());
-        apt.setTransactionId(transactionId);
-        apt.setBrokerId(brokerId);
-        apt.setClientId(clientId);
-        java.time.LocalDateTime from = java.time.LocalDateTime.now().minusDays(1);
-        java.time.LocalDateTime to = java.time.LocalDateTime.now().plusDays(1);
-        when(appointmentRepository.findByClientIdAndDateRange(clientId, from, to))
-                .thenReturn(List.of(apt));
-        TransactionParticipant coBroker = new TransactionParticipant();
-        coBroker.setUserId(coBrokerId);
-        coBroker.setTransactionId(transactionId);
-        coBroker.setRole(com.example.courtierprobackend.transactions.datalayer.enums.ParticipantRole.CO_BROKER);
-        when(transactionParticipantRepository.findByTransactionId(transactionId)).thenReturn(List.of(coBroker));
-        var result = appointmentService.getAppointmentsForClientByDateRange(clientId, from, to, coBrokerId, null);
-        assertThat(result).hasSize(1);
-    }
-
-    @Test
-    void getAppointmentsForClientByStatus_filtersByCoBrokerAccess() {
-        Appointment apt = new Appointment();
-        apt.setAppointmentId(UUID.randomUUID());
-        apt.setTransactionId(transactionId);
-        apt.setBrokerId(brokerId);
-        apt.setClientId(clientId);
-        com.example.courtierprobackend.appointments.datalayer.enums.AppointmentStatus status = com.example.courtierprobackend.appointments.datalayer.enums.AppointmentStatus.CONFIRMED;
-        when(appointmentRepository.findByClientIdAndStatusAndDeletedAtIsNullOrderByFromDateTimeAsc(clientId, status))
-                .thenReturn(List.of(apt));
-        TransactionParticipant coBroker = new TransactionParticipant();
-        coBroker.setUserId(coBrokerId);
-        coBroker.setTransactionId(transactionId);
-        coBroker.setRole(com.example.courtierprobackend.transactions.datalayer.enums.ParticipantRole.CO_BROKER);
-        when(transactionParticipantRepository.findByTransactionId(transactionId)).thenReturn(List.of(coBroker));
-        var result = appointmentService.getAppointmentsForClientByStatus(clientId, status, coBrokerId, null);
-        assertThat(result).hasSize(1);
-    }
-
-    @Test
-    void getAppointmentsForClientByDateRangeAndStatus_filtersByCoBrokerAccess() {
-        Appointment apt = new Appointment();
-        apt.setAppointmentId(UUID.randomUUID());
-        apt.setTransactionId(transactionId);
-        apt.setBrokerId(brokerId);
-        apt.setClientId(clientId);
-        java.time.LocalDateTime from = java.time.LocalDateTime.now().minusDays(1);
-        java.time.LocalDateTime to = java.time.LocalDateTime.now().plusDays(1);
-        com.example.courtierprobackend.appointments.datalayer.enums.AppointmentStatus status = com.example.courtierprobackend.appointments.datalayer.enums.AppointmentStatus.CONFIRMED;
-        when(appointmentRepository.findByClientIdAndDateRangeAndStatus(clientId, from, to, status))
-                .thenReturn(List.of(apt));
-        TransactionParticipant coBroker = new TransactionParticipant();
-        coBroker.setUserId(coBrokerId);
-        coBroker.setTransactionId(transactionId);
-        coBroker.setRole(com.example.courtierprobackend.transactions.datalayer.enums.ParticipantRole.CO_BROKER);
-        when(transactionParticipantRepository.findByTransactionId(transactionId)).thenReturn(List.of(coBroker));
-        var result = appointmentService.getAppointmentsForClientByDateRangeAndStatus(clientId, from, to, status, coBrokerId, null);
-        assertThat(result).hasSize(1);
-    }
 package com.example.courtierprobackend.appointments.businesslayer;
 
 import com.example.courtierprobackend.appointments.datalayer.Appointment;
 import com.example.courtierprobackend.appointments.datalayer.AppointmentRepository;
 import com.example.courtierprobackend.transactions.datalayer.TransactionParticipant;
 import com.example.courtierprobackend.transactions.datalayer.repositories.TransactionParticipantRepository;
+import com.example.courtierprobackend.transactions.datalayer.repositories.TransactionRepository;
 import com.example.courtierprobackend.user.dataaccesslayer.UserAccountRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -81,53 +23,33 @@ public class AppointmentServiceImplAccessControlTest {
     @Mock
     private UserAccountRepository userAccountRepository;
     @Mock
-    private com.example.courtierprobackend.transactions.datalayer.repositories.TransactionRepository transactionRepository;
+    private TransactionRepository transactionRepository;
     @Mock
     private com.example.courtierprobackend.audit.appointment_audit.businesslayer.AppointmentAuditService appointmentAuditService;
     @Mock
     private TransactionParticipantRepository transactionParticipantRepository;
 
     private AppointmentServiceImpl appointmentService;
-    private UUID clientId;
-    private UUID brokerId;
-    private UUID coBrokerId;
+
     private UUID transactionId;
+    private UUID brokerId;
+    private UUID clientId;
+    private UUID coBrokerId;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
         appointmentService = new AppointmentServiceImpl(
-                appointmentRepository,
-                userAccountRepository,
-                transactionRepository,
-                appointmentAuditService,
-                transactionParticipantRepository
+            appointmentRepository,
+            userAccountRepository,
+            transactionRepository,
+            appointmentAuditService,
+            transactionParticipantRepository
         );
-        clientId = UUID.randomUUID();
-        brokerId = UUID.randomUUID();
-        coBrokerId = UUID.randomUUID();
         transactionId = UUID.randomUUID();
-    }
-
-    @Test
-    void getAppointmentsForClient_filtersByCoBrokerAccess() {
-        Appointment apt = new Appointment();
-        apt.setAppointmentId(UUID.randomUUID());
-        apt.setTransactionId(transactionId);
-        apt.setBrokerId(brokerId);
-        apt.setClientId(clientId);
-        when(appointmentRepository.findByClientIdAndDeletedAtIsNullOrderByFromDateTimeAsc(clientId))
-                .thenReturn(List.of(apt));
-        TransactionParticipant coBroker = new TransactionParticipant();
-        coBroker.setUserId(coBrokerId);
-        coBroker.setTransactionId(transactionId);
-        coBroker.setRole(com.example.courtierprobackend.transactions.datalayer.enums.ParticipantRole.CO_BROKER);
-        when(transactionParticipantRepository.findByTransactionId(transactionId)).thenReturn(List.of(coBroker));
-        // Act: Call the service method with coBrokerId as requester
-        var result = appointmentService.getAppointmentsForClient(clientId, coBrokerId, null);
-        // Assert: The appointment should be returned for the co-broker
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getAppointmentId()).isEqualTo(apt.getAppointmentId());
+        brokerId = UUID.randomUUID();
+        clientId = UUID.randomUUID();
+        coBrokerId = UUID.randomUUID();
     }
 
     @Test

--- a/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImplAccessControlTest.java
+++ b/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImplAccessControlTest.java
@@ -129,4 +129,64 @@ public class AppointmentServiceImplAccessControlTest {
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getAppointmentId()).isEqualTo(apt.getAppointmentId());
     }
+
+    @Test
+    void getAppointmentsForClientByDateRange_filtersByCoBrokerAccess() {
+        Appointment apt = new Appointment();
+        apt.setAppointmentId(UUID.randomUUID());
+        apt.setTransactionId(transactionId);
+        apt.setBrokerId(brokerId);
+        apt.setClientId(clientId);
+        java.time.LocalDateTime from = java.time.LocalDateTime.now().minusDays(1);
+        java.time.LocalDateTime to = java.time.LocalDateTime.now().plusDays(1);
+        when(appointmentRepository.findByClientIdAndDateRange(clientId, from, to))
+                .thenReturn(List.of(apt));
+        TransactionParticipant coBroker = new TransactionParticipant();
+        coBroker.setUserId(coBrokerId);
+        coBroker.setTransactionId(transactionId);
+        coBroker.setRole(com.example.courtierprobackend.transactions.datalayer.enums.ParticipantRole.CO_BROKER);
+        when(transactionParticipantRepository.findByTransactionId(transactionId)).thenReturn(List.of(coBroker));
+        var result = appointmentService.getAppointmentsForClientByDateRange(clientId, from, to, coBrokerId, null);
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void getAppointmentsForClientByStatus_filtersByCoBrokerAccess() {
+        Appointment apt = new Appointment();
+        apt.setAppointmentId(UUID.randomUUID());
+        apt.setTransactionId(transactionId);
+        apt.setBrokerId(brokerId);
+        apt.setClientId(clientId);
+        com.example.courtierprobackend.appointments.datalayer.enums.AppointmentStatus status = com.example.courtierprobackend.appointments.datalayer.enums.AppointmentStatus.CONFIRMED;
+        when(appointmentRepository.findByClientIdAndStatusAndDeletedAtIsNullOrderByFromDateTimeAsc(clientId, status))
+                .thenReturn(List.of(apt));
+        TransactionParticipant coBroker = new TransactionParticipant();
+        coBroker.setUserId(coBrokerId);
+        coBroker.setTransactionId(transactionId);
+        coBroker.setRole(com.example.courtierprobackend.transactions.datalayer.enums.ParticipantRole.CO_BROKER);
+        when(transactionParticipantRepository.findByTransactionId(transactionId)).thenReturn(List.of(coBroker));
+        var result = appointmentService.getAppointmentsForClientByStatus(clientId, status, coBrokerId, null);
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void getAppointmentsForClientByDateRangeAndStatus_filtersByCoBrokerAccess() {
+        Appointment apt = new Appointment();
+        apt.setAppointmentId(UUID.randomUUID());
+        apt.setTransactionId(transactionId);
+        apt.setBrokerId(brokerId);
+        apt.setClientId(clientId);
+        java.time.LocalDateTime from = java.time.LocalDateTime.now().minusDays(1);
+        java.time.LocalDateTime to = java.time.LocalDateTime.now().plusDays(1);
+        com.example.courtierprobackend.appointments.datalayer.enums.AppointmentStatus status = com.example.courtierprobackend.appointments.datalayer.enums.AppointmentStatus.CONFIRMED;
+        when(appointmentRepository.findByClientIdAndDateRangeAndStatus(clientId, from, to, status))
+                .thenReturn(List.of(apt));
+        TransactionParticipant coBroker = new TransactionParticipant();
+        coBroker.setUserId(coBrokerId);
+        coBroker.setTransactionId(transactionId);
+        coBroker.setRole(com.example.courtierprobackend.transactions.datalayer.enums.ParticipantRole.CO_BROKER);
+        when(transactionParticipantRepository.findByTransactionId(transactionId)).thenReturn(List.of(coBroker));
+        var result = appointmentService.getAppointmentsForClientByDateRangeAndStatus(clientId, from, to, status, coBrokerId, null);
+        assertThat(result).hasSize(1);
+    }
 }

--- a/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImplTest.java
+++ b/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImplTest.java
@@ -235,7 +235,9 @@ class AppointmentServiceImplTest {
                 // Act
                 List<AppointmentResponseDTO> result = appointmentService.getAppointmentsForClientByDateRange(clientId,
                                 from,
-                                to);
+                                to,
+                                clientId,
+                                null);
 
                 // Assert
                 assertThat(result).hasSize(1);
@@ -279,7 +281,9 @@ class AppointmentServiceImplTest {
 
                 // Act
                 List<AppointmentResponseDTO> result = appointmentService.getAppointmentsForClientByStatus(clientId,
-                                AppointmentStatus.DECLINED);
+                                AppointmentStatus.DECLINED,
+                                clientId,
+                                null);
 
                 // Assert
                 assertThat(result).hasSize(1);
@@ -328,7 +332,9 @@ class AppointmentServiceImplTest {
                 // Act
                 List<AppointmentResponseDTO> result = appointmentService.getAppointmentsForClientByDateRangeAndStatus(
                                 clientId,
-                                from, to, AppointmentStatus.CONFIRMED);
+                                from, to, AppointmentStatus.CONFIRMED,
+                                clientId,
+                                null);
 
                 // Assert
                 assertThat(result).hasSize(1);

--- a/backend/src/test/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentControllerTest.java
+++ b/backend/src/test/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentControllerTest.java
@@ -230,7 +230,7 @@ class AppointmentControllerTest {
                 LocalDateTime to = LocalDateTime.now().plusDays(7);
                 AppointmentResponseDTO dto = createTestAppointmentDTO();
 
-                when(appointmentService.getAppointmentsForClientByDateRange(clientId, from, to))
+                when(appointmentService.getAppointmentsForClientByDateRange(clientId, from, to, clientId, null))
                                 .thenReturn(List.of(dto));
 
                 // Act
@@ -240,7 +240,7 @@ class AppointmentControllerTest {
                 // Assert
                 assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
                 assertThat(response.getBody()).hasSize(1);
-                verify(appointmentService).getAppointmentsForClientByDateRange(clientId, from, to);
+                verify(appointmentService).getAppointmentsForClientByDateRange(clientId, from, to, clientId, null);
         }
 
         @Test
@@ -250,7 +250,7 @@ class AppointmentControllerTest {
                 Jwt jwt = createJwt("auth0|client");
                 AppointmentResponseDTO dto = createTestAppointmentDTO();
 
-                when(appointmentService.getAppointmentsForClientByStatus(clientId, AppointmentStatus.DECLINED))
+                when(appointmentService.getAppointmentsForClientByStatus(clientId, AppointmentStatus.DECLINED, clientId, null))
                                 .thenReturn(List.of(dto));
 
                 // Act
@@ -260,7 +260,7 @@ class AppointmentControllerTest {
                 // Assert
                 assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
                 assertThat(response.getBody()).hasSize(1);
-                verify(appointmentService).getAppointmentsForClientByStatus(clientId, AppointmentStatus.DECLINED);
+                verify(appointmentService).getAppointmentsForClientByStatus(clientId, AppointmentStatus.DECLINED, clientId, null);
         }
 
         @Test
@@ -273,7 +273,7 @@ class AppointmentControllerTest {
                 AppointmentStatus status = AppointmentStatus.CONFIRMED;
                 AppointmentResponseDTO dto = createTestAppointmentDTO();
 
-                when(appointmentService.getAppointmentsForClientByDateRangeAndStatus(clientId, from, to, status))
+                when(appointmentService.getAppointmentsForClientByDateRangeAndStatus(clientId, from, to, status, clientId, null))
                                 .thenReturn(List.of(dto));
 
                 // Act
@@ -283,7 +283,7 @@ class AppointmentControllerTest {
                 // Assert
                 assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
                 assertThat(response.getBody()).hasSize(1);
-                verify(appointmentService).getAppointmentsForClientByDateRangeAndStatus(clientId, from, to, status);
+                verify(appointmentService).getAppointmentsForClientByDateRangeAndStatus(clientId, from, to, status, clientId, null);
         }
 
         // ========== GET /appointments Tests - Header Override ==========

--- a/frontend/src/features/appointments/api/useClientAppointments.ts
+++ b/frontend/src/features/appointments/api/useClientAppointments.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import axiosInstance from '@/shared/api/axiosInstance';
+import { type Appointment } from '../types';
+
+export function useClientAppointments(clientId: string) {
+    return useQuery({
+        queryKey: ['appointments', 'client', clientId],
+        queryFn: async () => {
+            const res = await axiosInstance.get<Appointment[]>(`/appointments/client/${encodeURIComponent(clientId)}`);
+            return res.data;
+        },
+        enabled: !!clientId,
+    });
+}

--- a/frontend/src/features/appointments/components/AppointmentList.tsx
+++ b/frontend/src/features/appointments/components/AppointmentList.tsx
@@ -49,7 +49,7 @@ export function AppointmentList({ groupedAppointments, allAppointments }: Appoin
 
                                 return (
                                     <AppointmentItem
-                                        key={apt.appointmentId + '-' + apt.clientId}
+                                        key={apt.appointmentId}
                                         appointment={apt}
                                         onClick={setSelectedAppointment}
                                         isBroker={isBroker}

--- a/frontend/src/features/appointments/components/AppointmentList.tsx
+++ b/frontend/src/features/appointments/components/AppointmentList.tsx
@@ -1,6 +1,8 @@
 import { AppointmentItem } from "./AppointmentItem";
 import { type Appointment } from "../types";
 import { format, parseISO } from "date-fns";
+import { useTranslation } from "react-i18next";
+import { enUS, fr } from "date-fns/locale";
 
 interface AppointmentListProps {
     groupedAppointments: Map<string, Appointment[]>;
@@ -13,6 +15,7 @@ import { AppointmentDetailModal } from "./AppointmentDetailModal";
 import { useAuth0 } from "@auth0/auth0-react";
 
 export function AppointmentList({ groupedAppointments, allAppointments }: AppointmentListProps) {
+    const { i18n } = useTranslation();
     const { user } = useAuth0();
     const isBroker = user?.['https://courtierpro.dev/roles']?.includes('BROKER') ?? false;
     const [selectedAppointment, setSelectedAppointment] = useState<Appointment | null>(null);
@@ -35,18 +38,18 @@ export function AppointmentList({ groupedAppointments, allAppointments }: Appoin
                 if (appointments.length === 0) return null;
 
                 const date = parseISO(dateKey);
-
+                const locale = i18n.language === 'fr' ? fr : enUS;
                 return (
                     <div key={dateKey} className="space-y-3">
-                        <h3 className="font-semibold text-lg sticky top-0 bg-background py-2">
-                            {format(date, 'EEEE, MMMM d, yyyy')}
+                        <h3 className="font-semibold text-lg py-2">
+                            {format(date, 'EEEE, MMMM d, yyyy', { locale })}
                         </h3>
                         <div className="grid gap-3">
                             {appointments.map((apt) => {
 
                                 return (
                                     <AppointmentItem
-                                        key={apt.appointmentId}
+                                        key={apt.appointmentId + '-' + apt.clientId}
                                         appointment={apt}
                                         onClick={setSelectedAppointment}
                                         isBroker={isBroker}

--- a/frontend/src/features/appointments/hooks/useClientAppointmentHistory.ts
+++ b/frontend/src/features/appointments/hooks/useClientAppointmentHistory.ts
@@ -14,7 +14,7 @@ export function useClientAppointmentHistory(clientId: string) {
         ...past.sort((a, b) => new Date(b.fromDateTime).getTime() - new Date(a.fromDateTime).getTime()),
     ];
 
-    const groupedAppointments = useMemo(() => groupAppointmentsByDate(sorted), [sorted]);
+    const groupedAppointments = useMemo(() => groupAppointmentsByDate(sorted), [appointments]);
 
     return { appointments: sorted, groupedAppointments, isLoading, isError, refetch };
 }

--- a/frontend/src/features/appointments/hooks/useClientAppointmentHistory.ts
+++ b/frontend/src/features/appointments/hooks/useClientAppointmentHistory.ts
@@ -1,0 +1,20 @@
+import { useMemo } from 'react';
+import { useClientAppointments } from '../api/useClientAppointments';
+import { groupAppointmentsByDate } from '../types';
+
+export function useClientAppointmentHistory(clientId: string) {
+    const { data: appointments = [], isLoading, isError, refetch } = useClientAppointments(clientId);
+
+    // Sort: upcoming first, then past
+    const now = new Date();
+    const upcoming = appointments.filter(a => new Date(a.fromDateTime) >= now);
+    const past = appointments.filter(a => new Date(a.fromDateTime) < now);
+    const sorted = [
+        ...upcoming.sort((a, b) => new Date(a.fromDateTime).getTime() - new Date(b.fromDateTime).getTime()),
+        ...past.sort((a, b) => new Date(b.fromDateTime).getTime() - new Date(a.fromDateTime).getTime()),
+    ];
+
+    const groupedAppointments = useMemo(() => groupAppointmentsByDate(sorted), [sorted]);
+
+    return { appointments: sorted, groupedAppointments, isLoading, isError, refetch };
+}

--- a/frontend/src/features/appointments/hooks/useClientAppointmentHistory.ts
+++ b/frontend/src/features/appointments/hooks/useClientAppointmentHistory.ts
@@ -14,7 +14,7 @@ export function useClientAppointmentHistory(clientId: string) {
         ...past.sort((a, b) => new Date(b.fromDateTime).getTime() - new Date(a.fromDateTime).getTime()),
     ];
 
-    const groupedAppointments = useMemo(() => groupAppointmentsByDate(sorted), [appointments]);
+    const groupedAppointments = useMemo(() => groupAppointmentsByDate(sorted), [sorted]);
 
     return { appointments: sorted, groupedAppointments, isLoading, isError, refetch };
 }

--- a/frontend/src/features/clients/components/ClientDetailModal.tsx
+++ b/frontend/src/features/clients/components/ClientDetailModal.tsx
@@ -97,6 +97,7 @@ export function ClientDetailModal({ client: clientProp, isOpen, onClose }: Clien
                             </div>
                         </div>
                     </section>
+                    <Separator />
 
                     <Separator />
 

--- a/frontend/src/features/clients/components/ClientDetailModal.tsx
+++ b/frontend/src/features/clients/components/ClientDetailModal.tsx
@@ -17,6 +17,10 @@ import { ClientTransactionItem } from './ClientTransactionItem';
 import { useClients } from '../hooks/useClients';
 import type { Client } from '../api/clientsApi';
 
+// Appointments
+import { AppointmentList } from '@/features/appointments/components/AppointmentList';
+import { useClientAppointmentHistory } from '@/features/appointments/hooks/useClientAppointmentHistory';
+
 interface ClientDetailModalProps {
     client: Client | null;
     isOpen: boolean;
@@ -35,6 +39,15 @@ export function ClientDetailModal({ client: clientProp, isOpen, onClose }: Clien
 
     // Use the new hook that returns ALL transactions for a client (across all brokers)
     const { data: transactions, isLoading, isError, refetch } = useAllClientTransactions(client?.id ?? '');
+
+    // Appointments logic
+    const {
+        appointments: appointmentHistory,
+        groupedAppointments: groupedAppointmentHistory,
+        isLoading: isAppointmentsLoading,
+        isError: isAppointmentsError,
+        refetch: refetchAppointments
+    } = useClientAppointmentHistory(client?.id ?? '');
 
     if (!client) return null;
 
@@ -132,6 +145,27 @@ export function ClientDetailModal({ client: clientProp, isOpen, onClose }: Clien
                                     </div>
                                 )}
                             </div>
+                        )}
+                    </section>
+
+                    {/* Appointments */}
+                    <section>
+                        <h4 className="text-sm font-medium text-foreground mb-3 flex items-center gap-2">
+                            <FileText className="h-4 w-4" />
+                            {t('title', { ns: 'appointments' })}
+                        </h4>
+                        {isAppointmentsLoading && <LoadingState message={t('loadingAppointments', 'Loading appointments...')} />}
+                        {isAppointmentsError && (
+                            <ErrorState message={t('errorLoadingAppointments', 'Could not load appointments.')} onRetry={refetchAppointments} />
+                        )}
+                        {!isAppointmentsLoading && !isAppointmentsError && (
+                            appointmentHistory.length === 0 ? (
+                                <p className="text-sm text-muted-foreground italic pl-6">{t('noAppointments', 'No appointments found.')}</p>
+                            ) : (
+                                <div className="pl-2">
+                                    <AppointmentList groupedAppointments={groupedAppointmentHistory} allAppointments={appointmentHistory} />
+                                </div>
+                            )
                         )}
                     </section>
                 </div>

--- a/frontend/src/features/transactions/components/TransactionSummary.tsx
+++ b/frontend/src/features/transactions/components/TransactionSummary.tsx
@@ -69,7 +69,7 @@ export function TransactionSummary({ transactionId, isReadOnly = false }: Transa
           </div>
           <div className="flex justify-between text-xs text-muted-foreground">
             {stages.map((stage, idx) => (
-              <div key={stage} className={`flex flex-col items-center ${idx <= stageIndex ? 'text-primary font-medium' : ''}`}>
+              <div key={stage + '-' + idx} className={`flex flex-col items-center ${idx <= stageIndex ? 'text-primary font-medium' : ''}`}>
                 <div className={`w-2 h-2 rounded-full mb-1 ${idx <= stageIndex ? (isTerminated && idx === stageIndex ? 'bg-destructive' : 'bg-primary') : 'bg-muted'}`} />
                 <span className="hidden sm:block">{stage}</span>
               </div>


### PR DESCRIPTION
Add appointment history to client profile, enforce access control for appointments/transactions, and move appointments section below transactions in the UI. Includes backend and test updates to restrict visibility to relevant brokers/co-brokers.