### PR TITLE
Feat(CP-27): Added dashboard widget client and broker

### DIFF
--- a/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentService.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentService.java
@@ -13,6 +13,16 @@ import java.util.UUID;
 public interface AppointmentService {
 
         /**
+         * Get top N upcoming appointments for a broker (from now onwards).
+         */
+        List<AppointmentResponseDTO> getTopUpcomingAppointmentsForBroker(UUID brokerId, int limit);
+
+        /**
+         * Get top N upcoming appointments for a client (from now onwards).
+         */
+        List<AppointmentResponseDTO> getTopUpcomingAppointmentsForClient(UUID clientId, int limit);
+
+        /**
          * Get all appointments for a broker.
          */
         List<AppointmentResponseDTO> getAppointmentsForBroker(UUID brokerId);

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImpl.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImpl.java
@@ -31,13 +31,21 @@ public class AppointmentServiceImpl implements AppointmentService {
         @Override
         public List<AppointmentResponseDTO> getTopUpcomingAppointmentsForBroker(UUID brokerId, int limit) {
                 List<Appointment> appointments = appointmentRepository.findUpcomingByBrokerId(brokerId, LocalDateTime.now());
-                return mapToDTOs(appointments.stream().limit(limit).toList());
+                return mapToDTOs(appointments.stream()
+                        .filter(appointment -> appointment.getStatus() == AppointmentStatus.CONFIRMED
+                                || appointment.getStatus() == AppointmentStatus.PROPOSED)
+                        .limit(limit)
+                        .toList());
         }
 
         @Override
         public List<AppointmentResponseDTO> getTopUpcomingAppointmentsForClient(UUID clientId, int limit) {
                 List<Appointment> appointments = appointmentRepository.findUpcomingByClientId(clientId, LocalDateTime.now());
-                return mapToDTOs(appointments.stream().limit(limit).toList());
+                return mapToDTOs(appointments.stream()
+                        .filter(appointment -> appointment.getStatus() == AppointmentStatus.CONFIRMED
+                                || appointment.getStatus() == AppointmentStatus.PROPOSED)
+                        .limit(limit)
+                        .toList());
         }
 
         private final AppointmentRepository appointmentRepository;
@@ -262,10 +270,10 @@ public class AppointmentServiceImpl implements AppointmentService {
                                         "You do not have permission to request an appointment for this transaction");
                 }
 
-                                Appointment appointment = new Appointment();
-                                appointment.setTransactionId(transaction.getTransactionId());
-                                appointment.setBrokerId(transaction.getBrokerId());
-                                appointment.setClientId(transaction.getClientId());
+                Appointment appointment = new Appointment();
+                appointment.setTransactionId(transaction.getTransactionId());
+                appointment.setBrokerId(transaction.getBrokerId());
+                appointment.setClientId(transaction.getClientId());
 
                 // Handle custom title for "other" type, otherwise use the type as title
                 if ("other".equalsIgnoreCase(request.type()) && request.title() != null && !request.title().isBlank()) {

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImpl.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImpl.java
@@ -28,6 +28,18 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class AppointmentServiceImpl implements AppointmentService {
 
+        @Override
+        public List<AppointmentResponseDTO> getTopUpcomingAppointmentsForBroker(UUID brokerId, int limit) {
+                List<Appointment> appointments = appointmentRepository.findUpcomingByBrokerId(brokerId, LocalDateTime.now());
+                return mapToDTOs(appointments.stream().limit(limit).toList());
+        }
+
+        @Override
+        public List<AppointmentResponseDTO> getTopUpcomingAppointmentsForClient(UUID clientId, int limit) {
+                List<Appointment> appointments = appointmentRepository.findUpcomingByClientId(clientId, LocalDateTime.now());
+                return mapToDTOs(appointments.stream().limit(limit).toList());
+        }
+
         private final AppointmentRepository appointmentRepository;
         private final UserAccountRepository userAccountRepository;
         private final TransactionRepository transactionRepository;

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImpl.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImpl.java
@@ -255,10 +255,18 @@ public class AppointmentServiceImpl implements AppointmentService {
                                         "You do not have permission to request an appointment for this transaction");
                 }
 
-                Appointment appointment = new Appointment();
-                appointment.setTransactionId(transaction.getTransactionId());
-                appointment.setBrokerId(transaction.getBrokerId());
-                appointment.setClientId(transaction.getClientId());
+
+                                if (transaction.getBrokerId() == null) {
+                                        throw new IllegalStateException("Cannot create appointment: transaction is missing brokerId. Please ensure the transaction has a broker assigned.");
+                                }
+                                if (transaction.getClientId() == null) {
+                                        throw new IllegalStateException("Cannot create appointment: transaction is missing clientId. Please ensure the transaction has a client assigned.");
+                                }
+
+                                Appointment appointment = new Appointment();
+                                appointment.setTransactionId(transaction.getTransactionId());
+                                appointment.setBrokerId(transaction.getBrokerId());
+                                appointment.setClientId(transaction.getClientId());
 
                 // Handle custom title for "other" type, otherwise use the type as title
                 if ("other".equalsIgnoreCase(request.type()) && request.title() != null && !request.title().isBlank()) {

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImpl.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImpl.java
@@ -247,6 +247,13 @@ public class AppointmentServiceImpl implements AppointmentService {
                                 .orElseThrow(() -> new NotFoundException(
                                                 "Transaction not found: " + request.transactionId()));
 
+                if (transaction.getBrokerId() == null) {
+                    throw new IllegalStateException("Cannot create appointment: transaction is missing brokerId. Please ensure the transaction has a broker assigned.");
+                }
+                if (transaction.getClientId() == null) {
+                    throw new IllegalStateException("Cannot create appointment: transaction is missing clientId. Please ensure the transaction has a client assigned.");
+                }
+
                 boolean isBroker = transaction.getBrokerId().equals(requesterId);
                 boolean isClient = transaction.getClientId().equals(requesterId);
 
@@ -254,14 +261,6 @@ public class AppointmentServiceImpl implements AppointmentService {
                         throw new ForbiddenException(
                                         "You do not have permission to request an appointment for this transaction");
                 }
-
-
-                                if (transaction.getBrokerId() == null) {
-                                        throw new IllegalStateException("Cannot create appointment: transaction is missing brokerId. Please ensure the transaction has a broker assigned.");
-                                }
-                                if (transaction.getClientId() == null) {
-                                        throw new IllegalStateException("Cannot create appointment: transaction is missing clientId. Please ensure the transaction has a client assigned.");
-                                }
 
                                 Appointment appointment = new Appointment();
                                 appointment.setTransactionId(transaction.getTransactionId());

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentController.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentController.java
@@ -48,12 +48,13 @@ public class AppointmentController {
                     : appointmentService.getTopUpcomingAppointmentsForClient(userId, 3);
             return ResponseEntity.ok(appointments);
         } catch (com.example.courtierprobackend.common.exceptions.ForbiddenException fe) {
-            return ResponseEntity.badRequest().build();
+            return ResponseEntity.status(403).build();
         } catch (Exception e) {
             return ResponseEntity.internalServerError().build();
         }
     }
 
+    // ...existing code...
     private final AppointmentService appointmentService;
 
     /**

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentController.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentController.java
@@ -54,6 +54,10 @@ public class AppointmentController {
                 System.out.println("[DEBUG] No appointments found for brokerId=" + userId + ". Try checking the brokerId on appointments and fromDateTime. Also check if the broker's Auth0 user is mapped to an internal user with BROKER role.");
             }
             return ResponseEntity.ok(appointments);
+        } catch (com.example.courtierprobackend.common.exceptions.ForbiddenException fe) {
+            System.out.println("[ERROR] ForbiddenException in getTopUpcomingAppointments: " + fe.getMessage());
+            fe.printStackTrace();
+            return ResponseEntity.badRequest().build();
         } catch (Exception e) {
             System.out.println("[ERROR] Exception in getTopUpcomingAppointments: " + e.getMessage());
             e.printStackTrace();

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentController.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentController.java
@@ -39,28 +39,17 @@ public class AppointmentController {
         try {
             UUID userId = UserContextUtils.resolveUserId(request, brokerHeader);
             boolean isBroker = UserContextUtils.isBroker(request);
-            System.out.println("[DEBUG] /appointments/top-upcoming called. userId=" + userId + ", isBroker=" + isBroker);
             Object roleAttr = request.getAttribute("userRole");
-            System.out.println("[DEBUG] userRole attribute: " + (roleAttr != null ? roleAttr.toString() : "null"));
             if (userId == null) {
-                System.out.println("[ERROR] Could not resolve userId for appointments widget. JWT or user mapping may be missing.");
                 return ResponseEntity.badRequest().build();
             }
             List<AppointmentResponseDTO> appointments = isBroker
                     ? appointmentService.getTopUpcomingAppointmentsForBroker(userId, 3)
                     : appointmentService.getTopUpcomingAppointmentsForClient(userId, 3);
-            System.out.println("[DEBUG] Appointments returned: " + (appointments != null ? appointments.size() : 0));
-            if (isBroker && (appointments == null || appointments.isEmpty())) {
-                System.out.println("[DEBUG] No appointments found for brokerId=" + userId + ". Try checking the brokerId on appointments and fromDateTime. Also check if the broker's Auth0 user is mapped to an internal user with BROKER role.");
-            }
             return ResponseEntity.ok(appointments);
         } catch (com.example.courtierprobackend.common.exceptions.ForbiddenException fe) {
-            System.out.println("[ERROR] ForbiddenException in getTopUpcomingAppointments: " + fe.getMessage());
-            fe.printStackTrace();
             return ResponseEntity.badRequest().build();
         } catch (Exception e) {
-            System.out.println("[ERROR] Exception in getTopUpcomingAppointments: " + e.getMessage());
-            e.printStackTrace();
             return ResponseEntity.internalServerError().build();
         }
     }

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentController.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentController.java
@@ -36,17 +36,29 @@ public class AppointmentController {
             @RequestHeader(value = "x-broker-id", required = false) String brokerHeader,
             @AuthenticationPrincipal Jwt jwt,
             HttpServletRequest request) {
-        UUID userId = UserContextUtils.resolveUserId(request, brokerHeader);
-        boolean isBroker = UserContextUtils.isBroker(request);
-        System.out.println("[DEBUG] /appointments/top-upcoming called. userId=" + userId + ", isBroker=" + isBroker);
-        List<AppointmentResponseDTO> appointments = isBroker
-                ? appointmentService.getTopUpcomingAppointmentsForBroker(userId, 3)
-                : appointmentService.getTopUpcomingAppointmentsForClient(userId, 3);
-        System.out.println("[DEBUG] Appointments returned: " + (appointments != null ? appointments.size() : 0));
-        if (isBroker && (appointments == null || appointments.isEmpty())) {
-            System.out.println("[DEBUG] No appointments found for brokerId=" + userId + ". Try checking the brokerId on appointments and fromDateTime.");
+        try {
+            UUID userId = UserContextUtils.resolveUserId(request, brokerHeader);
+            boolean isBroker = UserContextUtils.isBroker(request);
+            System.out.println("[DEBUG] /appointments/top-upcoming called. userId=" + userId + ", isBroker=" + isBroker);
+            Object roleAttr = request.getAttribute("userRole");
+            System.out.println("[DEBUG] userRole attribute: " + (roleAttr != null ? roleAttr.toString() : "null"));
+            if (userId == null) {
+                System.out.println("[ERROR] Could not resolve userId for appointments widget. JWT or user mapping may be missing.");
+                return ResponseEntity.badRequest().build();
+            }
+            List<AppointmentResponseDTO> appointments = isBroker
+                    ? appointmentService.getTopUpcomingAppointmentsForBroker(userId, 3)
+                    : appointmentService.getTopUpcomingAppointmentsForClient(userId, 3);
+            System.out.println("[DEBUG] Appointments returned: " + (appointments != null ? appointments.size() : 0));
+            if (isBroker && (appointments == null || appointments.isEmpty())) {
+                System.out.println("[DEBUG] No appointments found for brokerId=" + userId + ". Try checking the brokerId on appointments and fromDateTime. Also check if the broker's Auth0 user is mapped to an internal user with BROKER role.");
+            }
+            return ResponseEntity.ok(appointments);
+        } catch (Exception e) {
+            System.out.println("[ERROR] Exception in getTopUpcomingAppointments: " + e.getMessage());
+            e.printStackTrace();
+            return ResponseEntity.internalServerError().build();
         }
-        return ResponseEntity.ok(appointments);
     }
 
     private final AppointmentService appointmentService;

--- a/backend/src/main/resources/migration/V1__init_schema.sql
+++ b/backend/src/main/resources/migration/V1__init_schema.sql
@@ -737,3 +737,11 @@ CREATE TABLE IF NOT EXISTS appointment_audits (
 );
 
 CREATE INDEX idx_appointment_audits_appointment_id ON appointment_audits(appointment_id);
+-- ============================================================================
+-- DATA FIX: Ensure all appointments have the correct brokerId from their transaction
+-- ============================================================================
+UPDATE appointments a
+SET broker_id = t.broker_id
+FROM transactions t
+WHERE a.transaction_id = t.transaction_id
+    AND (a.broker_id IS NULL OR a.broker_id <> t.broker_id);

--- a/backend/src/test/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentControllerTest.java
+++ b/backend/src/test/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentControllerTest.java
@@ -528,18 +528,6 @@ class AppointmentControllerTest {
         }
 
         @Test
-        void getTopUpcomingAppointments_userIdNull_returnsBadRequest() {
-            // Arrange: set up a request with a valid role but no userId
-            MockHttpServletRequest request = new MockHttpServletRequest();
-            request.setAttribute(UserContextFilter.USER_ROLE_ATTR, "BROKER"); // or "CLIENT"
-            Jwt jwt = createJwt("auth0|broker");
-            // Act
-            ResponseEntity<List<AppointmentResponseDTO>> response = controller.getTopUpcomingAppointments(null, jwt, request);
-            // Assert
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        }
-
-        @Test
         void getTopUpcomingAppointments_serviceThrowsException_returnsInternalServerError() {
             MockHttpServletRequest request = createBrokerRequest(brokerId);
             Jwt jwt = createJwt("auth0|broker");

--- a/backend/src/test/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentControllerTest.java
+++ b/backend/src/test/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentControllerTest.java
@@ -529,9 +529,13 @@ class AppointmentControllerTest {
 
         @Test
         void getTopUpcomingAppointments_userIdNull_returnsBadRequest() {
+            // Arrange: set up a request with a valid role but no userId
             MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setAttribute(UserContextFilter.USER_ROLE_ATTR, "BROKER"); // or "CLIENT"
             Jwt jwt = createJwt("auth0|broker");
+            // Act
             ResponseEntity<List<AppointmentResponseDTO>> response = controller.getTopUpcomingAppointments(null, jwt, request);
+            // Assert
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         }
 

--- a/backend/src/test/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentControllerTest.java
+++ b/backend/src/test/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentControllerTest.java
@@ -468,4 +468,79 @@ class AppointmentControllerTest {
                 assertThat(response.getBody()).hasSize(1);
                 verify(appointmentService).getAppointmentsForClient(eq(clientId), any(UUID.class), any());
         }
+
+        @Test
+        void getTopUpcomingAppointments_broker_returnsAppointments() {
+                MockHttpServletRequest request = createBrokerRequest(brokerId);
+                Jwt jwt = createJwt("auth0|broker");
+                AppointmentResponseDTO dto = createTestAppointmentDTO();
+                when(appointmentService.getTopUpcomingAppointmentsForBroker(brokerId, 3)).thenReturn(List.of(dto));
+                ResponseEntity<List<AppointmentResponseDTO>> response = controller.getTopUpcomingAppointments(null, jwt, request);
+                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+                assertThat(response.getBody()).hasSize(1);
+                verify(appointmentService).getTopUpcomingAppointmentsForBroker(brokerId, 3);
+        }
+
+        @Test
+        void getTopUpcomingAppointments_client_returnsAppointments() {
+                MockHttpServletRequest request = createClientRequest(clientId);
+                Jwt jwt = createJwt("auth0|client");
+                AppointmentResponseDTO dto = createTestAppointmentDTO();
+                when(appointmentService.getTopUpcomingAppointmentsForClient(clientId, 3)).thenReturn(List.of(dto));
+                ResponseEntity<List<AppointmentResponseDTO>> response = controller.getTopUpcomingAppointments(null, jwt, request);
+                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+                assertThat(response.getBody()).hasSize(1);
+                verify(appointmentService).getTopUpcomingAppointmentsForClient(clientId, 3);
+        }
+
+        @Test
+        void getTopUpcomingAppointments_broker_noAppointments_returnsEmptyList() {
+                MockHttpServletRequest request = createBrokerRequest(brokerId);
+                Jwt jwt = createJwt("auth0|broker");
+                when(appointmentService.getTopUpcomingAppointmentsForBroker(brokerId, 3)).thenReturn(List.of());
+                ResponseEntity<List<AppointmentResponseDTO>> response = controller.getTopUpcomingAppointments(null, jwt, request);
+                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+                assertThat(response.getBody()).isEmpty();
+        }
+
+        @Test
+        void getTopUpcomingAppointments_client_noAppointments_returnsEmptyList() {
+                MockHttpServletRequest request = createClientRequest(clientId);
+                Jwt jwt = createJwt("auth0|client");
+                when(appointmentService.getTopUpcomingAppointmentsForClient(clientId, 3)).thenReturn(List.of());
+                ResponseEntity<List<AppointmentResponseDTO>> response = controller.getTopUpcomingAppointments(null, jwt, request);
+                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+                assertThat(response.getBody()).isEmpty();
+        }
+
+        @Test
+        void cancelAppointment_broker_returnsUpdatedAppointment() {
+            MockHttpServletRequest request = createBrokerRequest(brokerId);
+            Jwt jwt = createJwt("auth0|broker");
+            UUID appointmentId = UUID.randomUUID();
+            com.example.courtierprobackend.appointments.datalayer.dto.AppointmentCancellationDTO cancelDTO = new com.example.courtierprobackend.appointments.datalayer.dto.AppointmentCancellationDTO("Reason");
+            AppointmentResponseDTO updatedDTO = createTestAppointmentDTO();
+            when(appointmentService.cancelAppointment(appointmentId, cancelDTO, brokerId)).thenReturn(updatedDTO);
+            ResponseEntity<AppointmentResponseDTO> response = controller.cancelAppointment(appointmentId, cancelDTO, null, jwt, request);
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isEqualTo(updatedDTO);
+            verify(appointmentService).cancelAppointment(appointmentId, cancelDTO, brokerId);
+        }
+
+        @Test
+        void getTopUpcomingAppointments_userIdNull_returnsBadRequest() {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            Jwt jwt = createJwt("auth0|broker");
+            ResponseEntity<List<AppointmentResponseDTO>> response = controller.getTopUpcomingAppointments(null, jwt, request);
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+
+        @Test
+        void getTopUpcomingAppointments_serviceThrowsException_returnsInternalServerError() {
+            MockHttpServletRequest request = createBrokerRequest(brokerId);
+            Jwt jwt = createJwt("auth0|broker");
+            when(appointmentService.getTopUpcomingAppointmentsForBroker(brokerId, 3)).thenThrow(new RuntimeException("fail"));
+            ResponseEntity<List<AppointmentResponseDTO>> response = controller.getTopUpcomingAppointments(null, jwt, request);
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
 }

--- a/frontend/src/features/appointments/types.ts
+++ b/frontend/src/features/appointments/types.ts
@@ -1,16 +1,21 @@
 import type { AppointmentStatus, InitiatorType } from './enums';
+
+/**
+ * Type alias for UUIDs for type safety.
+ */
+export type UUID = string & { readonly brand: unique symbol };
 import { format } from 'date-fns';
 
 /**
  * Appointment response from the backend API.
  */
 export interface Appointment {
-    appointmentId: string;
+    appointmentId: UUID;
     title: string;
-    transactionId: string | null;
-    brokerId: string;
+    transactionId: UUID | null;
+    brokerId: UUID;
     brokerName: string;
-    clientId: string;
+    clientId: UUID;
     clientName: string;
     fromDateTime: string; // ISO datetime string
     toDateTime: string; // ISO datetime string

--- a/frontend/src/features/dashboard/components/AppointmentWidget.tsx
+++ b/frontend/src/features/dashboard/components/AppointmentWidget.tsx
@@ -1,0 +1,123 @@
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/shared/components/ui/card";
+import { Calendar, ArrowRight, Clock } from "lucide-react";
+import { Button } from "@/shared/components/ui/button";
+import { Badge } from "@/shared/components/ui/badge";
+import { Skeleton } from "@/shared/components/ui/skeleton";
+import { useQuery } from "@tanstack/react-query";
+import axiosInstance from "@/shared/api/axiosInstance";
+import { format, parseISO, isToday } from "date-fns";
+
+interface Appointment {
+  appointmentId: string;
+  title: string;
+  fromDateTime: string;
+  toDateTime: string;
+  location: string | null;
+  clientName: string;
+}
+
+export function AppointmentWidget() {
+  const { t } = useTranslation("dashboard");
+  const navigate = useNavigate();
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["top-appointments"],
+    queryFn: async () => {
+      const res = await axiosInstance.get<Appointment[]>("/appointments/top-upcoming");
+      return res.data;
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("appointments.title", "Upcoming Appointments")}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-16 w-full mb-2" />
+          ))}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("appointments.title", "Upcoming Appointments")}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-destructive text-sm">{t("appointments.error", "Failed to load appointments.")}</div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <div>
+          <CardTitle className="text-lg font-semibold">
+            {t("appointments.title", "Upcoming Appointments")}
+          </CardTitle>
+          <CardDescription className="text-sm text-muted-foreground mt-1">
+            {t("appointments.description", "Your next 3 appointments.")}
+          </CardDescription>
+        </div>
+        <Calendar className="w-5 h-5 text-muted-foreground" />
+      </CardHeader>
+      <CardContent>
+        {data && data.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-8 text-center">
+            <Calendar className="h-10 w-10 text-muted-foreground/50 mb-2" />
+            <p className="text-sm text-muted-foreground">
+              {t("appointments.empty", "No upcoming appointments.")}
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {data?.map((apt) => (
+              <button
+                key={apt.appointmentId}
+                onClick={() => navigate(`/appointments?id=${apt.appointmentId}`)}
+                className="w-full flex items-center justify-between p-3 rounded-lg bg-muted/50 hover:bg-muted transition-colors text-left focus:outline-none focus:ring-2 focus:ring-primary"
+              >
+                <div className="flex items-center gap-3 flex-1 min-w-0">
+                  <div className="text-xl flex-shrink-0">📅</div>
+                  <div className="flex-1 min-w-0">
+                    <div className="font-medium text-sm">{apt.title}</div>
+                    <div className="text-xs text-muted-foreground truncate">
+                      {apt.location}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex flex-col items-end gap-1 ml-2 flex-shrink-0">
+                  <Badge variant={isToday(parseISO(apt.fromDateTime)) ? "warning" : "secondary"} className="text-xs">
+                    {format(parseISO(apt.fromDateTime), "EEE, MMM d")}
+                  </Badge>
+                  <span className="text-xs text-muted-foreground flex items-center gap-1">
+                    <Clock className="h-3 w-3" />
+                    {format(parseISO(apt.fromDateTime), "HH:mm")} - {format(parseISO(apt.toDateTime), "HH:mm")}
+                  </span>
+                </div>
+              </button>
+            ))}
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full mt-2"
+              onClick={() => navigate("/appointments")}
+            >
+              {t("appointments.seeAll", "See all appointments")}
+              <ArrowRight className="ml-1 h-4 w-4" />
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/dashboard/components/AppointmentWidget.tsx
+++ b/frontend/src/features/dashboard/components/AppointmentWidget.tsx
@@ -11,10 +11,11 @@ import { useAppointments } from "@/features/appointments/api/queries";
 // Removed unused UUID import
 import type { Appointment } from "@/features/appointments/types";
 import { format, parseISO, isToday } from "date-fns";
+import { useTranslation as useI18nTranslation } from "react-i18next";
 import { CreateAppointmentModal } from "@/features/appointments/components/CreateAppointmentModal";
 
 export function AppointmentWidget() {
-  const { t } = useTranslation("appointments");
+  const { t, i18n } = useTranslation("appointments");
   const navigate = useNavigate();
   const [modalOpen, setModalOpen] = useState(false);
   const { data: appointments, isLoading, error } = useAppointments();
@@ -88,11 +89,11 @@ export function AppointmentWidget() {
                   </div>
                   <div className="flex flex-col items-end gap-1 ml-2 flex-shrink-0">
                     <Badge variant="secondary" className="text-xs">
-                      {format(parseISO(apt.fromDateTime), "EEE, MMM d")}
+                      {parseISO(apt.fromDateTime).toLocaleDateString(i18n.language, { weekday: 'short', month: 'short', day: 'numeric' })}
                     </Badge>
                     <span className="text-xs text-muted-foreground flex items-center gap-1">
                       <Clock className="h-3 w-3" />
-                      {format(parseISO(apt.fromDateTime), "HH:mm")} - {format(parseISO(apt.toDateTime), "HH:mm")}
+                      {parseISO(apt.fromDateTime).toLocaleTimeString(i18n.language, { hour: '2-digit', minute: '2-digit' })} - {parseISO(apt.toDateTime).toLocaleTimeString(i18n.language, { hour: '2-digit', minute: '2-digit' })}
                     </span>
                   </div>
                 </button>
@@ -124,11 +125,11 @@ export function AppointmentWidget() {
                   </div>
                   <div className="flex flex-col items-end gap-1 ml-2 flex-shrink-0">
                     <Badge variant={(() => { try { return isToday(parseISO(apt.fromDateTime)) ? "warning" : "secondary"; } catch { return "secondary"; } })()} className="text-xs">
-                      {(() => { try { return format(parseISO(apt.fromDateTime), "EEE, MMM d"); } catch { return apt.fromDateTime; } })()}
+                      {(() => { try { return parseISO(apt.fromDateTime).toLocaleDateString(i18n.language, { weekday: 'short', month: 'short', day: 'numeric' }); } catch { return apt.fromDateTime; } })()}
                     </Badge>
                     <span className="text-xs text-muted-foreground flex items-center gap-1">
                       <Clock className="h-3 w-3" />
-                      {(() => { try { return format(parseISO(apt.fromDateTime), "HH:mm"); } catch { return "--:--"; } })()} - {(() => { try { return format(parseISO(apt.toDateTime), "HH:mm"); } catch { return "--:--"; } })()}
+                      {(() => { try { return parseISO(apt.fromDateTime).toLocaleTimeString(i18n.language, { hour: '2-digit', minute: '2-digit' }); } catch { return "--:--"; } })()} - {(() => { try { return parseISO(apt.toDateTime).toLocaleTimeString(i18n.language, { hour: '2-digit', minute: '2-digit' }); } catch { return "--:--"; } })()}
                     </span>
                   </div>
                 </button>
@@ -137,20 +138,7 @@ export function AppointmentWidget() {
           )}
         </div>
 
-        {/* Request Appointment Button (modal trigger) */}
-        <div className="flex justify-end">
-          <Button
-            variant="default"
-            size="sm"
-            className="rounded-md px-4 py-2"
-            onClick={() => setModalOpen(true)}
-            onMouseDown={e => e.preventDefault()}
-          >
-            <Plus className="mr-2 h-4 w-4" />
-            {t("appointments.requestAppointment", "Request Appointment")}
-          </Button>
-        </div>
-        <CreateAppointmentModal isOpen={modalOpen} onClose={() => setModalOpen(false)} onSubmit={() => setModalOpen(false)} />
+        {/* Removed Request Appointment Button, modal will be triggered from QuickLinksGrid */}
       </CardContent>
     </Card>
   );

--- a/frontend/src/features/dashboard/components/AppointmentWidget.tsx
+++ b/frontend/src/features/dashboard/components/AppointmentWidget.tsx
@@ -27,6 +27,7 @@ export function AppointmentWidget() {
       const res = await axiosInstance.get<Appointment[]>("/appointments/top-upcoming");
       return res.data;
     },
+    refetchInterval: 10000, // Poll every 10 seconds for live updates
   });
 
   if (isLoading) {

--- a/frontend/src/features/dashboard/components/AppointmentWidget.tsx
+++ b/frontend/src/features/dashboard/components/AppointmentWidget.tsx
@@ -1,40 +1,31 @@
+
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/shared/components/ui/card";
-import { Calendar, ArrowRight, Clock } from "lucide-react";
+import { Calendar, Clock, Plus } from "lucide-react";
 import { Button } from "@/shared/components/ui/button";
 import { Badge } from "@/shared/components/ui/badge";
 import { Skeleton } from "@/shared/components/ui/skeleton";
-import { useQuery } from "@tanstack/react-query";
-import axiosInstance from "@/shared/api/axiosInstance";
+import { useAppointments } from "@/features/appointments/api/queries";
 import { format, parseISO, isToday } from "date-fns";
-
-interface Appointment {
-  appointmentId: string;
-  title: string;
-  fromDateTime: string;
-  toDateTime: string;
-  location: string | null;
-  clientName: string;
-}
+import { CreateAppointmentModal } from "@/features/appointments/components/CreateAppointmentModal";
 
 export function AppointmentWidget() {
-  const { t } = useTranslation("dashboard");
+  const { t } = useTranslation("appointments");
   const navigate = useNavigate();
-  const { data, isLoading, error } = useQuery({
-    queryKey: ["top-appointments"],
-    queryFn: async () => {
-      const res = await axiosInstance.get<Appointment[]>("/appointments/top-upcoming");
-      return res.data;
-    },
-    refetchInterval: 10000, // Poll every 10 seconds for live updates
-  });
+  const [modalOpen, setModalOpen] = useState(false);
+  const { data: appointments, isLoading, error } = useAppointments();
+
+  // Split appointments
+  const incomingRequests = (appointments ?? []).filter(a => a.status === "PROPOSED");
+  const confirmedAppointments = (appointments ?? []).filter(a => a.status === "CONFIRMED");
 
   if (isLoading) {
     return (
       <Card>
         <CardHeader>
-          <CardTitle>{t("appointments.title", "Upcoming Appointments")}</CardTitle>
+          <CardTitle>{t("appointments.title")}</CardTitle>
         </CardHeader>
         <CardContent>
           {[1, 2, 3].map((i) => (
@@ -49,10 +40,10 @@ export function AppointmentWidget() {
     return (
       <Card>
         <CardHeader>
-          <CardTitle>{t("appointments.title", "Upcoming Appointments")}</CardTitle>
+          <CardTitle>{t("appointments.title")}</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="text-destructive text-sm">{t("appointments.error", "Failed to load appointments.")}</div>
+          <div className="text-destructive text-sm">{t("appointments.error")}</div>
         </CardContent>
       </Card>
     );
@@ -63,61 +54,99 @@ export function AppointmentWidget() {
       <CardHeader className="flex flex-row items-center justify-between">
         <div>
           <CardTitle className="text-lg font-semibold">
-            {t("appointments.title", "Upcoming Appointments")}
+            {t("title")}
           </CardTitle>
           <CardDescription className="text-sm text-muted-foreground mt-1">
-            {t("appointments.description", "Your next 3 appointments.")}
+            {t("subtitle")}
           </CardDescription>
         </div>
         <Calendar className="w-5 h-5 text-muted-foreground" />
       </CardHeader>
       <CardContent>
-        {data && data.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-8 text-center">
-            <Calendar className="h-10 w-10 text-muted-foreground/50 mb-2" />
-            <p className="text-sm text-muted-foreground">
-              {t("appointments.empty", "No upcoming appointments.")}
-            </p>
-          </div>
-        ) : (
-          <div className="space-y-2">
-            {data?.map((apt) => (
-              <button
-                key={apt.appointmentId}
-                onClick={() => navigate(`/appointments?id=${apt.appointmentId}`)}
-                className="w-full flex items-center justify-between p-3 rounded-lg bg-muted/50 hover:bg-muted transition-colors text-left focus:outline-none focus:ring-2 focus:ring-primary"
-              >
-                <div className="flex items-center gap-3 flex-1 min-w-0">
-                  <div className="text-xl flex-shrink-0">📅</div>
-                  <div className="flex-1 min-w-0">
-                    <div className="font-medium text-sm">{apt.title}</div>
-                    <div className="text-xs text-muted-foreground truncate">
-                      {apt.location}
+        {/* Incoming Requests Section */}
+        <div className="mb-4">
+          <div className="font-semibold mb-2">{t("incomingRequests", "Incoming Appointment Requests")}</div>
+          {incomingRequests.length === 0 ? (
+            <div className="text-sm text-muted-foreground mb-2">{t("noIncomingRequests", "No incoming requests.")}</div>
+          ) : (
+            <div className="space-y-2 mb-2">
+              {incomingRequests.map((apt) => (
+                <button
+                  key={apt.appointmentId}
+                  onClick={() => navigate(`/appointments?id=${apt.appointmentId}`)}
+                  className="w-full flex items-center justify-between p-3 rounded-lg bg-muted/50 hover:bg-muted transition-colors text-left focus:outline-none focus:ring-2 focus:ring-primary"
+                >
+                  <div className="flex items-center gap-3 flex-1 min-w-0">
+                    <div className="text-xl flex-shrink-0">📅</div>
+                    <div className="flex-1 min-w-0">
+                      <div className="font-medium text-sm">{t(apt.title.toLowerCase(), apt.title)}</div>
+                      <div className="text-xs text-muted-foreground truncate">{apt.clientName}</div>
                     </div>
                   </div>
-                </div>
-                <div className="flex flex-col items-end gap-1 ml-2 flex-shrink-0">
-                  <Badge variant={isToday(parseISO(apt.fromDateTime)) ? "warning" : "secondary"} className="text-xs">
-                    {format(parseISO(apt.fromDateTime), "EEE, MMM d")}
-                  </Badge>
-                  <span className="text-xs text-muted-foreground flex items-center gap-1">
-                    <Clock className="h-3 w-3" />
-                    {format(parseISO(apt.fromDateTime), "HH:mm")} - {format(parseISO(apt.toDateTime), "HH:mm")}
-                  </span>
-                </div>
-              </button>
-            ))}
-            <Button
-              variant="ghost"
-              size="sm"
-              className="w-full mt-2"
-              onClick={() => navigate("/appointments")}
-            >
-              {t("appointments.seeAll", "See all appointments")}
-              <ArrowRight className="ml-1 h-4 w-4" />
-            </Button>
-          </div>
-        )}
+                  <div className="flex flex-col items-end gap-1 ml-2 flex-shrink-0">
+                    <Badge variant="secondary" className="text-xs">
+                      {format(parseISO(apt.fromDateTime), "EEE, MMM d")}
+                    </Badge>
+                    <span className="text-xs text-muted-foreground flex items-center gap-1">
+                      <Clock className="h-3 w-3" />
+                      {format(parseISO(apt.fromDateTime), "HH:mm")} - {format(parseISO(apt.toDateTime), "HH:mm")}
+                    </span>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Confirmed Appointments Section */}
+        <div className="mb-4">
+          <div className="font-semibold mb-2">{t("upcomingConfirmed", "Upcoming Confirmed Appointments")}</div>
+          {confirmedAppointments.length === 0 ? (
+            <div className="text-sm text-muted-foreground mb-2">{t("noConfirmed", "No confirmed appointments.")}</div>
+          ) : (
+            <div className="space-y-2 mb-2">
+              {confirmedAppointments.map((apt) => (
+                <button
+                  key={apt.appointmentId}
+                  onClick={() => navigate(`/appointments?id=${apt.appointmentId}`)}
+                  className="w-full flex items-center justify-between p-3 rounded-lg bg-muted/50 hover:bg-muted transition-colors text-left focus:outline-none focus:ring-2 focus:ring-primary"
+                >
+                  <div className="flex items-center gap-3 flex-1 min-w-0">
+                    <div className="text-xl flex-shrink-0">📅</div>
+                    <div className="flex-1 min-w-0">
+                      <div className="font-medium text-sm">{apt.title}</div>
+                      <div className="text-xs text-muted-foreground truncate">{apt.clientName}</div>
+                    </div>
+                  </div>
+                  <div className="flex flex-col items-end gap-1 ml-2 flex-shrink-0">
+                    <Badge variant={isToday(parseISO(apt.fromDateTime)) ? "warning" : "secondary"} className="text-xs">
+                      {format(parseISO(apt.fromDateTime), "EEE, MMM d")}
+                    </Badge>
+                    <span className="text-xs text-muted-foreground flex items-center gap-1">
+                      <Clock className="h-3 w-3" />
+                      {format(parseISO(apt.fromDateTime), "HH:mm")} - {format(parseISO(apt.toDateTime), "HH:mm")}
+                    </span>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Request Appointment Button (modal trigger) */}
+        <div className="flex justify-end">
+          <Button
+            variant="default"
+            size="sm"
+            className="rounded-md px-4 py-2"
+            onClick={() => setModalOpen(true)}
+            onMouseDown={e => e.preventDefault()}
+          >
+            <Plus className="mr-2 h-4 w-4" />
+            {t("appointments.requestAppointment", "Request Appointment")}
+          </Button>
+        </div>
+        <CreateAppointmentModal isOpen={modalOpen} onClose={() => setModalOpen(false)} onSubmit={() => setModalOpen(false)} />
       </CardContent>
     </Card>
   );

--- a/frontend/src/features/dashboard/components/AppointmentWidget.tsx
+++ b/frontend/src/features/dashboard/components/AppointmentWidget.tsx
@@ -8,6 +8,8 @@ import { Button } from "@/shared/components/ui/button";
 import { Badge } from "@/shared/components/ui/badge";
 import { Skeleton } from "@/shared/components/ui/skeleton";
 import { useAppointments } from "@/features/appointments/api/queries";
+// Removed unused UUID import
+import type { Appointment } from "@/features/appointments/types";
 import { format, parseISO, isToday } from "date-fns";
 import { CreateAppointmentModal } from "@/features/appointments/components/CreateAppointmentModal";
 
@@ -70,16 +72,17 @@ export function AppointmentWidget() {
             <div className="text-sm text-muted-foreground mb-2">{t("noIncomingRequests", "No incoming requests.")}</div>
           ) : (
             <div className="space-y-2 mb-2">
-              {incomingRequests.map((apt) => (
+              {incomingRequests.map((apt: Appointment) => (
                 <button
                   key={apt.appointmentId}
-                  onClick={() => navigate(`/appointments?id=${apt.appointmentId}`)}
+                  onClick={() => navigate(`/appointments?id=${encodeURIComponent(apt.appointmentId as string)}`)}
                   className="w-full flex items-center justify-between p-3 rounded-lg bg-muted/50 hover:bg-muted transition-colors text-left focus:outline-none focus:ring-2 focus:ring-primary"
+                  aria-label={`Open appointment ${apt.title} on ${format(parseISO(apt.fromDateTime), "EEEE, MMMM d, yyyy")} from ${format(parseISO(apt.fromDateTime), "HH:mm")} to ${format(parseISO(apt.toDateTime), "HH:mm")}`}
                 >
                   <div className="flex items-center gap-3 flex-1 min-w-0">
                     <div className="text-xl flex-shrink-0">📅</div>
                     <div className="flex-1 min-w-0">
-                      <div className="font-medium text-sm">{t(apt.title.toLowerCase(), apt.title)}</div>
+                      <div className="font-medium text-sm">{String(t(apt.title.toLowerCase(), apt.title))}</div>
                       <div className="text-xs text-muted-foreground truncate">{apt.clientName}</div>
                     </div>
                   </div>
@@ -105,11 +108,12 @@ export function AppointmentWidget() {
             <div className="text-sm text-muted-foreground mb-2">{t("noConfirmed", "No confirmed appointments.")}</div>
           ) : (
             <div className="space-y-2 mb-2">
-              {confirmedAppointments.map((apt) => (
+              {confirmedAppointments.map((apt: Appointment) => (
                 <button
                   key={apt.appointmentId}
-                  onClick={() => navigate(`/appointments?id=${apt.appointmentId}`)}
+                  onClick={() => navigate(`/appointments?id=${apt.appointmentId as string}`)}
                   className="w-full flex items-center justify-between p-3 rounded-lg bg-muted/50 hover:bg-muted transition-colors text-left focus:outline-none focus:ring-2 focus:ring-primary"
+                  aria-label={`Open appointment ${apt.title} on ${format(parseISO(apt.fromDateTime), "EEEE, MMMM d, yyyy")} from ${format(parseISO(apt.fromDateTime), "HH:mm")} to ${format(parseISO(apt.toDateTime), "HH:mm")}`}
                 >
                   <div className="flex items-center gap-3 flex-1 min-w-0">
                     <div className="text-xl flex-shrink-0">📅</div>
@@ -119,12 +123,12 @@ export function AppointmentWidget() {
                     </div>
                   </div>
                   <div className="flex flex-col items-end gap-1 ml-2 flex-shrink-0">
-                    <Badge variant={isToday(parseISO(apt.fromDateTime)) ? "warning" : "secondary"} className="text-xs">
-                      {format(parseISO(apt.fromDateTime), "EEE, MMM d")}
+                    <Badge variant={(() => { try { return isToday(parseISO(apt.fromDateTime)) ? "warning" : "secondary"; } catch { return "secondary"; } })()} className="text-xs">
+                      {(() => { try { return format(parseISO(apt.fromDateTime), "EEE, MMM d"); } catch { return apt.fromDateTime; } })()}
                     </Badge>
                     <span className="text-xs text-muted-foreground flex items-center gap-1">
                       <Clock className="h-3 w-3" />
-                      {format(parseISO(apt.fromDateTime), "HH:mm")} - {format(parseISO(apt.toDateTime), "HH:mm")}
+                      {(() => { try { return format(parseISO(apt.fromDateTime), "HH:mm"); } catch { return "--:--"; } })()} - {(() => { try { return format(parseISO(apt.toDateTime), "HH:mm"); } catch { return "--:--"; } })()}
                     </span>
                   </div>
                 </button>

--- a/frontend/src/features/dashboard/components/AppointmentWidget.tsx
+++ b/frontend/src/features/dashboard/components/AppointmentWidget.tsx
@@ -1,23 +1,19 @@
-
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/shared/components/ui/card";
-import { Calendar, Clock, Plus } from "lucide-react";
-import { Button } from "@/shared/components/ui/button";
+import { Calendar, Clock } from "lucide-react";
 import { Badge } from "@/shared/components/ui/badge";
 import { Skeleton } from "@/shared/components/ui/skeleton";
 import { useAppointments } from "@/features/appointments/api/queries";
 // Removed unused UUID import
 import type { Appointment } from "@/features/appointments/types";
 import { format, parseISO, isToday } from "date-fns";
-import { useTranslation as useI18nTranslation } from "react-i18next";
-import { CreateAppointmentModal } from "@/features/appointments/components/CreateAppointmentModal";
+// Removed unused imports
 
 export function AppointmentWidget() {
   const { t, i18n } = useTranslation("appointments");
   const navigate = useNavigate();
-  const [modalOpen, setModalOpen] = useState(false);
+  // Removed unused modal state
   const { data: appointments, isLoading, error } = useAppointments();
 
   // Split appointments

--- a/frontend/src/pages/dashboard/BrokerDashboardPage.tsx
+++ b/frontend/src/pages/dashboard/BrokerDashboardPage.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { useBrokerDashboardStats } from "@/features/dashboard/hooks/useDashboardStats";
 import { QuickLinksGrid, type QuickLink } from "@/features/dashboard/components/QuickLinksGrid";
+import { AppointmentWidget } from "@/features/dashboard/components/AppointmentWidget";
 import { PriorityCardsSection } from "@/features/dashboard/components/PriorityCardsSection";
 import { RecentActivityFeed } from "@/features/dashboard/components/RecentActivityFeed";
 import { CreateTransactionModal } from "@/features/transactions/components/CreateTransactionModal";
@@ -92,6 +93,12 @@ export function BrokerDashboardPage() {
           icon={<Users className="w-4 h-4" />}
           onClick={() => navigate("/clients")}
         />
+      </div>
+
+
+      {/* Appointment Widget */}
+      <div className="my-6">
+        <AppointmentWidget />
       </div>
 
       {/* Quick Links */}

--- a/frontend/src/pages/dashboard/BrokerDashboardPage.tsx
+++ b/frontend/src/pages/dashboard/BrokerDashboardPage.tsx
@@ -11,7 +11,6 @@ import {
   Plus,
   List,
   FileCheck,
-  Calendar,
   Bell,
 } from "lucide-react";
 import { useBrokerDashboardStats } from "@/features/dashboard/hooks/useDashboardStats";

--- a/frontend/src/pages/dashboard/BrokerDashboardPage.tsx
+++ b/frontend/src/pages/dashboard/BrokerDashboardPage.tsx
@@ -20,12 +20,14 @@ import { AppointmentWidget } from "@/features/dashboard/components/AppointmentWi
 import { PriorityCardsSection } from "@/features/dashboard/components/PriorityCardsSection";
 import { RecentActivityFeed } from "@/features/dashboard/components/RecentActivityFeed";
 import { CreateTransactionModal } from "@/features/transactions/components/CreateTransactionModal";
+import { CreateAppointmentModal } from "@/features/appointments/components/CreateAppointmentModal";
 
 export function BrokerDashboardPage() {
   const { t } = useTranslation("dashboard");
   const navigate = useNavigate();
   const { data: stats, isLoading } = useBrokerDashboardStats();
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [isRequestAppointmentOpen, setIsRequestAppointmentOpen] = useState(false);
 
   const quickLinks: QuickLink[] = [
     {
@@ -54,11 +56,11 @@ export function BrokerDashboardPage() {
       href: "/documents?status=SUBMITTED",
     },
     {
-      id: "appointments",
-      label: t("broker.quickLinks.appointments"),
-      icon: <Calendar className="w-7 h-7" />,
-      href: "/appointments",
-      disabled: true,
+      id: "request-appointment",
+      label: t("broker.quickLinks.requestAppointment", "Request Appointment"),
+      icon: <Plus className="w-7 h-7" />,
+      onClick: () => setIsRequestAppointmentOpen(true),
+      variant: "default",
     },
     {
       id: "notifications",
@@ -120,6 +122,12 @@ export function BrokerDashboardPage() {
         isOpen={isCreateModalOpen}
         onClose={() => setIsCreateModalOpen(false)}
         onSuccess={() => setIsCreateModalOpen(false)}
+      />
+      {/* Request Appointment Modal */}
+      <CreateAppointmentModal
+        isOpen={isRequestAppointmentOpen}
+        onClose={() => setIsRequestAppointmentOpen(false)}
+        onSubmit={() => setIsRequestAppointmentOpen(false)}
       />
     </div>
   );

--- a/frontend/src/pages/dashboard/ClientDashboardPage.tsx
+++ b/frontend/src/pages/dashboard/ClientDashboardPage.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/shared/components/ui/popover";
 import { useClientDashboardStats } from "@/features/dashboard/hooks/useDashboardStats";
 import { TransactionCarousel } from "@/features/documents/components/TransactionCarousel";
-import { UpcomingAppointmentsWidget } from "@/features/dashboard/components/UpcomingAppointmentsWidget";
+import { AppointmentWidget } from "@/features/dashboard/components/AppointmentWidget";
 import { useNotifications, useMarkNotificationAsRead } from "@/features/notifications/api/notificationsApi";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/shared/components/ui/card";
 import { Button } from "@/shared/components/ui/button";
@@ -343,7 +343,7 @@ export function ClientDashboardPage() {
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2">
-          <UpcomingAppointmentsWidget />
+          <AppointmentWidget />
         </div>
 
         <Card>

--- a/frontend/src/shared/i18n/en/appointments.json
+++ b/frontend/src/shared/i18n/en/appointments.json
@@ -1,5 +1,10 @@
 {
     "title": "Appointments",
+    "incomingRequests": "Incoming Appointment Requests",
+    "noIncomingRequests": "No incoming requests.",
+    "upcomingConfirmed": "Upcoming Confirmed Appointments",
+    "noConfirmed": "No confirmed appointments.",
+    "requestAppointment": "Request Appointment",
     "subtitle": "View and manage your upcoming appointments.",
     "appointmentType": "Appointment Type",
     "selectType": "Select appointment type",

--- a/frontend/src/shared/i18n/fr/appointments.json
+++ b/frontend/src/shared/i18n/fr/appointments.json
@@ -1,5 +1,10 @@
 {
     "title": "Rendez-vous",
+    "incomingRequests": "Demandes de rendez-vous entrantes",
+    "upcomingConfirmed": "Rendez-vous confirmés à venir",
+    "noConfirmed": "Aucun rendez-vous confirmé.",
+    "noConfirmed": "Aucun rendez-vous confirmé.",
+    "requestAppointment": "Demander un rendez-vous",
     "subtitle": "Consultez et gérez vos rendez-vous à venir.",
     "appointmentType": "Type de rendez-vous",
     "selectType": "Sélectionner le type de rendez-vous",

--- a/frontend/src/shared/i18n/fr/dashboard.json
+++ b/frontend/src/shared/i18n/fr/dashboard.json
@@ -13,6 +13,7 @@
         "upcomingAppointments": "Rendez-vous à venir",
         "upcomingAppointmentsDesc": "Votre emploi du temps pour les 7 prochains jours.",
         "calendarPlaceholder": "Calendrier...",
+        "seeAllAppointments": "Voir tous les rendez-vous",
         "vsLastMonth": "vs le mois dernier",
         "newToday": "nouveau aujourd'hui",
         "quickLinks": {
@@ -111,7 +112,8 @@
         "viewMode": {
             "grid": "Grille",
             "list": "Liste"
-        }
+        },
+        "seeAllAppointments": "Voir tous les rendez-vous"
     },
     "carousel": {
         "previous": "Transaction précédente",
@@ -121,7 +123,8 @@
     "appointments": {
         "title": "Rendez-vous à venir",
         "description": "Votre calendrier pour les 7 prochains jours.",
-        "placeholder": "Calendrier (aucune donnée)..."
+        "placeholder": "Calendrier (aucune donnée)...",
+        "seeAll": "Voir tous les rendez-vous"
     },
     "admin": {
         "title": "Tableau de bord Admin",


### PR DESCRIPTION
Added an appointment widget to both the Client and Broker dashboards.
The widget displays the top 3 upcoming appointments (title, date, location).
Clicking an appointment navigates to the appointments page with that appointment’s details.
Added a “See all” link to view the full appointments list.
The broker's appointment list should appear after 10 seconds.