### PR TITLE
Feat(CP-28): House visits and visitors for selling transactions

### DIFF
--- a/backend/src/main/java/com/example/courtierprobackend/analytics/AnalyticsDTO.java
+++ b/backend/src/main/java/com/example/courtierprobackend/analytics/AnalyticsDTO.java
@@ -22,9 +22,14 @@ public record AnalyticsDTO(
         Map<String, Integer> buyerStageDistribution,
         Map<String, Integer> sellerStageDistribution,
 
-        // House Visits
+        // House Visits (Buy-Side)
         int totalHouseVisits,
         double avgHouseVisitsPerClosedTransaction,
+
+        // Showings (Sell-Side)
+        int totalSellShowings,
+        double avgSellShowingsPerClosedTransaction,
+        int totalSellVisitors,
 
         // Properties (Buy-Side)
         int totalProperties,

--- a/backend/src/main/java/com/example/courtierprobackend/analytics/AnalyticsService.java
+++ b/backend/src/main/java/com/example/courtierprobackend/analytics/AnalyticsService.java
@@ -37,6 +37,10 @@ public class AnalyticsService {
                 List<Transaction> allTransactions = transactionRepository.findAllByBrokerId(brokerId);
                 int total = allTransactions.size();
 
+                // Load all appointments once for use across multiple sections
+                List<Appointment> allAppointments = appointmentRepository
+                                .findByBrokerIdOrderByFromDateTimeAsc(brokerId);
+
                 // --- Transaction Overview ---
                 int active = 0, closed = 0, terminated = 0, buy = 0, sell = 0;
                 for (Transaction t : allTransactions) {
@@ -94,12 +98,11 @@ public class AnalyticsService {
                                                 t -> t.getSellerStage().name(),
                                                 Collectors.collectingAndThen(Collectors.counting(), Long::intValue)));
 
-                // --- House Visits ---
+                // --- House Visits (Buy-Side) ---
                 List<Transaction> buyTransactions = allTransactions.stream()
                                 .filter(t -> t.getSide() == TransactionSide.BUY_SIDE).toList();
 
-                // Single batch query → Map<transactionId, count>
-                Map<UUID, Integer> hvCountsByTxId = new java.util.HashMap<>();
+                Map<UUID, Integer> hvCountsByTxId = new HashMap<>();
                 if (!buyTransactions.isEmpty()) {
                         List<UUID> buyTxIds = buyTransactions.stream().map(Transaction::getTransactionId).toList();
                         for (Object[] row : appointmentRepository.countConfirmedHouseVisitsByTransactionIds(buyTxIds)) {
@@ -117,6 +120,40 @@ public class AnalyticsService {
                                         .mapToInt(t -> hvCountsByTxId.getOrDefault(t.getTransactionId(), 0))
                                         .sum();
                         avgHouseVisits = round((double) closedHV / closedBuyTransactions.size());
+                }
+
+                // --- Sell-Side Showings ---
+                List<Transaction> sellTransactionsForShowings = allTransactions.stream()
+                                .filter(t -> t.getSide() == TransactionSide.SELL_SIDE).toList();
+
+                Map<UUID, Integer> showingsCountsByTxId = new HashMap<>();
+                Map<UUID, Integer> visitorsCountsByTxId = new HashMap<>();
+                if (!sellTransactionsForShowings.isEmpty()) {
+                        List<UUID> sellTxIds = sellTransactionsForShowings.stream().map(Transaction::getTransactionId).toList();
+                        for (Object[] row : appointmentRepository.countConfirmedShowingsByTransactionIds(sellTxIds)) {
+                                showingsCountsByTxId.put((UUID) row[0], ((Number) row[1]).intValue());
+                        }
+                        for (Appointment a : allAppointments) {
+                                if (a.getTransactionId() != null
+                                                && ("open_house".equalsIgnoreCase(a.getTitle()) || "private_showing".equalsIgnoreCase(a.getTitle()))
+                                                && a.getStatus() == AppointmentStatus.CONFIRMED
+                                                && a.getNumberOfVisitors() != null) {
+                                        visitorsCountsByTxId.merge(a.getTransactionId(), a.getNumberOfVisitors(), Integer::sum);
+                                }
+                        }
+                }
+
+                int totalSellShowings = showingsCountsByTxId.values().stream().mapToInt(Integer::intValue).sum();
+                int totalSellVisitors = visitorsCountsByTxId.values().stream().mapToInt(Integer::intValue).sum();
+
+                List<Transaction> closedSellTransactions = sellTransactionsForShowings.stream()
+                                .filter(t -> t.getStatus() == TransactionStatus.CLOSED_SUCCESSFULLY).toList();
+                double avgSellShowings = 0.0;
+                if (!closedSellTransactions.isEmpty()) {
+                        int closedShowings = closedSellTransactions.stream()
+                                        .mapToInt(t -> showingsCountsByTxId.getOrDefault(t.getTransactionId(), 0))
+                                        .sum();
+                        avgSellShowings = round((double) closedShowings / closedSellTransactions.size());
                 }
 
                 // --- Properties (Buy-Side) ---
@@ -259,8 +296,6 @@ public class AnalyticsService {
                 double avgDocsPerTx = total > 0 ? round((double) totalDocuments / total) : 0;
 
                 // --- Appointments ---
-                List<Appointment> allAppointments = appointmentRepository
-                                .findByBrokerIdOrderByFromDateTimeAsc(brokerId);
                 int totalAppointments = allAppointments.size();
 
                 long confirmed = allAppointments.stream().filter(a -> a.getStatus() == AppointmentStatus.CONFIRMED)
@@ -341,6 +376,7 @@ public class AnalyticsService {
                                 openedPerMonth, closedPerMonth,
                                 buyerStageDistribution, sellerStageDistribution,
                                 totalHouseVisits, avgHouseVisits,
+                                totalSellShowings, avgSellShowings, totalSellVisitors,
                                 totalProperties, avgPropertiesPerBuy, propertyInterestRate,
                                 propertiesNeedingInfo, propertiesWithOffers, propertiesWithoutOffers,
                                 totalBuyerOffers, buyerOfferAcceptanceRate, avgOfferRounds,

--- a/backend/src/main/java/com/example/courtierprobackend/analytics/AnalyticsService.java
+++ b/backend/src/main/java/com/example/courtierprobackend/analytics/AnalyticsService.java
@@ -133,13 +133,8 @@ public class AnalyticsService {
                         for (Object[] row : appointmentRepository.countConfirmedShowingsByTransactionIds(sellTxIds)) {
                                 showingsCountsByTxId.put((UUID) row[0], ((Number) row[1]).intValue());
                         }
-                        for (Appointment a : allAppointments) {
-                                if (a.getTransactionId() != null
-                                                && ("open_house".equalsIgnoreCase(a.getTitle()) || "private_showing".equalsIgnoreCase(a.getTitle()))
-                                                && a.getStatus() == AppointmentStatus.CONFIRMED
-                                                && a.getNumberOfVisitors() != null) {
-                                        visitorsCountsByTxId.merge(a.getTransactionId(), a.getNumberOfVisitors(), Integer::sum);
-                                }
+                        for (Object[] row : appointmentRepository.sumVisitorsByTransactionIds(sellTxIds)) {
+                                visitorsCountsByTxId.put((UUID) row[0], ((Number) row[1]).intValue());
                         }
                 }
 

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentService.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentService.java
@@ -110,4 +110,9 @@ public interface AppointmentService {
                         com.example.courtierprobackend.appointments.datalayer.dto.AppointmentCancellationDTO cancelDTO,
                         UUID requesterId);
 
+        /**
+         * Update the visitor count for an open_house or private_showing appointment.
+         */
+        AppointmentResponseDTO updateVisitorCount(UUID appointmentId, int numberOfVisitors, UUID requesterId);
+
 }

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImpl.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImpl.java
@@ -755,7 +755,7 @@ public class AppointmentServiceImpl implements AppointmentService {
         @Override
         @Transactional
         public AppointmentResponseDTO updateVisitorCount(UUID appointmentId, int numberOfVisitors, UUID requesterId) {
-                Appointment appointment = appointmentRepository.findByAppointmentIdAndDeletedAtIsNull(appointmentId)
+                Appointment appointment = appointmentRepository.findByAppointmentId(appointmentId)
                                 .orElseThrow(() -> new NotFoundException("Appointment not found: " + appointmentId));
 
                 // Verify requester is the broker on this appointment

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImpl.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImpl.java
@@ -763,6 +763,11 @@ public class AppointmentServiceImpl implements AppointmentService {
                         throw new ForbiddenException("Only the broker can update the visitor count");
                 }
 
+                // Validate appointment status - only confirmed appointments can have visitor counts
+                if (appointment.getStatus() != com.example.courtierprobackend.appointments.datalayer.enums.AppointmentStatus.CONFIRMED) {
+                        throw new IllegalArgumentException("Visitor count can only be updated for confirmed appointments");
+                }
+
                 // Validate appointment type
                 String title = appointment.getTitle();
                 if (!"open_house".equalsIgnoreCase(title) && !"private_showing".equalsIgnoreCase(title)) {

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImpl.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImpl.java
@@ -59,6 +59,7 @@ public class AppointmentServiceImpl implements AppointmentService {
         private final com.example.courtierprobackend.notifications.businesslayer.NotificationService notificationService;
         private final com.example.courtierprobackend.transactions.datalayer.repositories.TransactionParticipantRepository transactionParticipantRepository;
         private final com.example.courtierprobackend.transactions.datalayer.repositories.PropertyRepository propertyRepository;
+        private final com.example.courtierprobackend.transactions.datalayer.repositories.VisitorRepository visitorRepository;
 
         public AppointmentServiceImpl(AppointmentRepository appointmentRepository,
                         UserAccountRepository userAccountRepository,
@@ -68,7 +69,8 @@ public class AppointmentServiceImpl implements AppointmentService {
                         com.example.courtierprobackend.audit.timeline_audit.businesslayer.TimelineService timelineService,
                         com.example.courtierprobackend.notifications.businesslayer.NotificationService notificationService,
                         com.example.courtierprobackend.transactions.datalayer.repositories.TransactionParticipantRepository transactionParticipantRepository,
-                        com.example.courtierprobackend.transactions.datalayer.repositories.PropertyRepository propertyRepository) {
+                        com.example.courtierprobackend.transactions.datalayer.repositories.PropertyRepository propertyRepository,
+                        com.example.courtierprobackend.transactions.datalayer.repositories.VisitorRepository visitorRepository) {
                 this.appointmentRepository = appointmentRepository;
                 this.userAccountRepository = userAccountRepository;
                 this.transactionRepository = transactionRepository;
@@ -78,6 +80,7 @@ public class AppointmentServiceImpl implements AppointmentService {
                 this.notificationService = notificationService;
                 this.transactionParticipantRepository = transactionParticipantRepository;
                 this.propertyRepository = propertyRepository;
+                this.visitorRepository = visitorRepository;
         }
 
         @Override
@@ -339,6 +342,30 @@ public class AppointmentServiceImpl implements AppointmentService {
                                                 "Property does not belong to this transaction");
                         }
                         appointment.setPropertyId(request.propertyId());
+                }
+
+                // Validate open_house and private_showing types: requires SELL_SIDE transaction
+                if ("open_house".equalsIgnoreCase(request.type()) || "private_showing".equalsIgnoreCase(request.type())) {
+                        if (transaction.getSide() != com.example.courtierprobackend.transactions.datalayer.enums.TransactionSide.SELL_SIDE) {
+                                throw new IllegalArgumentException(
+                                                "Open house and private showing appointments can only be created for sell-side transactions");
+                        }
+
+                        if ("private_showing".equalsIgnoreCase(request.type())) {
+                                appointment.setNumberOfVisitors(1); // default for private showing
+                                if (request.visitorId() != null) {
+                                        com.example.courtierprobackend.transactions.datalayer.Visitor visitor = visitorRepository
+                                                        .findByVisitorId(request.visitorId())
+                                                        .orElseThrow(() -> new NotFoundException(
+                                                                        "Visitor not found: " + request.visitorId()));
+                                        if (!visitor.getTransactionId().equals(transaction.getTransactionId())) {
+                                                throw new IllegalArgumentException(
+                                                                "Visitor does not belong to this transaction");
+                                        }
+                                        appointment.setVisitorId(request.visitorId());
+                                }
+                        }
+                        // open_house: numberOfVisitors left null, set after event concludes
                 }
 
                 LocalDateTime start = LocalDateTime.of(request.date(), request.startTime());
@@ -725,6 +752,37 @@ public class AppointmentServiceImpl implements AppointmentService {
                 return mapToDTO(saved, getUserNamesMap(List.of(saved)));
         }
 
+        @Override
+        @Transactional
+        public AppointmentResponseDTO updateVisitorCount(UUID appointmentId, int numberOfVisitors, UUID requesterId) {
+                Appointment appointment = appointmentRepository.findByAppointmentIdAndDeletedAtIsNull(appointmentId)
+                                .orElseThrow(() -> new NotFoundException("Appointment not found: " + appointmentId));
+
+                // Verify requester is the broker on this appointment
+                if (!appointment.getBrokerId().equals(requesterId)) {
+                        throw new ForbiddenException("Only the broker can update the visitor count");
+                }
+
+                // Validate appointment type
+                String title = appointment.getTitle();
+                if (!"open_house".equalsIgnoreCase(title) && !"private_showing".equalsIgnoreCase(title)) {
+                        throw new IllegalArgumentException("Visitor count can only be updated for open house or private showing appointments");
+                }
+
+                // For open_house, event must have concluded
+                if ("open_house".equalsIgnoreCase(title) && appointment.getToDateTime().isAfter(LocalDateTime.now())) {
+                        throw new IllegalArgumentException("Visitor count for open house can only be set after the event concludes");
+                }
+
+                if (numberOfVisitors < 0) {
+                        throw new IllegalArgumentException("Number of visitors cannot be negative");
+                }
+
+                appointment.setNumberOfVisitors(numberOfVisitors);
+                Appointment saved = appointmentRepository.save(appointment);
+                return mapToDTO(saved, getUserNamesMap(List.of(saved)));
+        }
+
         private AppointmentResponseDTO mapToDTO(Appointment apt, Map<UUID, String> userNames) {
                 return new AppointmentResponseDTO(
                                 apt.getAppointmentId(),
@@ -747,7 +805,9 @@ public class AppointmentServiceImpl implements AppointmentService {
                                 apt.getCancelledBy(),
                                 apt.getCreatedAt(),
                                 apt.getUpdatedAt(),
-                                apt.getPropertyId());
+                                apt.getPropertyId(),
+                                apt.getNumberOfVisitors(),
+                                apt.getVisitorId());
         }
 
         /**

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/datalayer/Appointment.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/datalayer/Appointment.java
@@ -96,6 +96,12 @@ public class Appointment {
     @Column(name = "reminder_sent", nullable = false)
     private Boolean reminderSent = false;
 
+    @Column(name = "number_of_visitors")
+    private Integer numberOfVisitors;
+
+    @Column(name = "visitor_id")
+    private UUID visitorId;
+
     public Appointment() {
     }
 
@@ -335,5 +341,21 @@ public class Appointment {
 
     public void setReminderSent(Boolean reminderSent) {
         this.reminderSent = reminderSent;
+    }
+
+    public Integer getNumberOfVisitors() {
+        return numberOfVisitors;
+    }
+
+    public void setNumberOfVisitors(Integer numberOfVisitors) {
+        this.numberOfVisitors = numberOfVisitors;
+    }
+
+    public UUID getVisitorId() {
+        return visitorId;
+    }
+
+    public void setVisitorId(UUID visitorId) {
+        this.visitorId = visitorId;
     }
 }

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/datalayer/AppointmentRepository.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/datalayer/AppointmentRepository.java
@@ -190,4 +190,56 @@ public interface AppointmentRepository extends JpaRepository<Appointment, Long> 
                         "AND a.deletedAt IS NULL " +
                         "GROUP BY a.transactionId")
         List<Object[]> countConfirmedHouseVisitsByTransactionIds(@Param("transactionIds") List<UUID> transactionIds);
+
+        /**
+         * Count confirmed sell-side showings (open_house + private_showing) for a transaction.
+         */
+        @Query("SELECT COUNT(a) FROM Appointment a WHERE a.transactionId = :transactionId " +
+                        "AND a.title IN ('open_house', 'private_showing') " +
+                        "AND a.status = com.example.courtierprobackend.appointments.datalayer.enums.AppointmentStatus.CONFIRMED " +
+                        "AND a.deletedAt IS NULL")
+        int countConfirmedShowingsByTransactionId(@Param("transactionId") UUID transactionId);
+
+        /**
+         * Sum numberOfVisitors for confirmed sell-side showings for a transaction.
+         */
+        @Query("SELECT COALESCE(SUM(a.numberOfVisitors), 0) FROM Appointment a " +
+                        "WHERE a.transactionId = :transactionId " +
+                        "AND a.title IN ('open_house', 'private_showing') " +
+                        "AND a.status = com.example.courtierprobackend.appointments.datalayer.enums.AppointmentStatus.CONFIRMED " +
+                        "AND a.deletedAt IS NULL")
+        int sumVisitorsByTransactionId(@Param("transactionId") UUID transactionId);
+
+        /**
+         * Count confirmed private showings for a specific visitor (for timesVisited).
+         */
+        @Query("SELECT COUNT(a) FROM Appointment a WHERE a.visitorId = :visitorId " +
+                        "AND a.title = 'private_showing' " +
+                        "AND a.status = com.example.courtierprobackend.appointments.datalayer.enums.AppointmentStatus.CONFIRMED " +
+                        "AND a.deletedAt IS NULL")
+        int countConfirmedShowingsByVisitorId(@Param("visitorId") UUID visitorId);
+
+        /**
+         * Batch count confirmed private showings per visitor for a list of visitor IDs.
+         * Returns rows of [visitorId, count].
+         */
+        @Query("SELECT a.visitorId, COUNT(a) FROM Appointment a " +
+                        "WHERE a.visitorId IN :visitorIds " +
+                        "AND a.title = 'private_showing' " +
+                        "AND a.status = com.example.courtierprobackend.appointments.datalayer.enums.AppointmentStatus.CONFIRMED " +
+                        "AND a.deletedAt IS NULL " +
+                        "GROUP BY a.visitorId")
+        List<Object[]> countConfirmedShowingsByVisitorIds(@Param("visitorIds") List<UUID> visitorIds);
+
+        /**
+         * Batch count confirmed sell-side showings per transaction for a list of transaction IDs.
+         * Returns rows of [transactionId, count].
+         */
+        @Query("SELECT a.transactionId, COUNT(a) FROM Appointment a " +
+                        "WHERE a.transactionId IN :transactionIds " +
+                        "AND a.title IN ('open_house', 'private_showing') " +
+                        "AND a.status = com.example.courtierprobackend.appointments.datalayer.enums.AppointmentStatus.CONFIRMED " +
+                        "AND a.deletedAt IS NULL " +
+                        "GROUP BY a.transactionId")
+        List<Object[]> countConfirmedShowingsByTransactionIds(@Param("transactionIds") List<UUID> transactionIds);
 }

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/datalayer/AppointmentRepository.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/datalayer/AppointmentRepository.java
@@ -211,6 +211,18 @@ public interface AppointmentRepository extends JpaRepository<Appointment, Long> 
         int sumVisitorsByTransactionId(@Param("transactionId") UUID transactionId);
 
         /**
+         * Batch sum numberOfVisitors for confirmed sell-side showings per transaction.
+         * Returns rows of [transactionId, visitorSum].
+         */
+        @Query("SELECT a.transactionId, COALESCE(SUM(a.numberOfVisitors), 0) FROM Appointment a " +
+                        "WHERE a.transactionId IN :transactionIds " +
+                        "AND a.title IN ('open_house', 'private_showing') " +
+                        "AND a.status = com.example.courtierprobackend.appointments.datalayer.enums.AppointmentStatus.CONFIRMED " +
+                        "AND a.deletedAt IS NULL " +
+                        "GROUP BY a.transactionId")
+        List<Object[]> sumVisitorsByTransactionIds(@Param("transactionIds") List<UUID> transactionIds);
+
+        /**
          * Count confirmed private showings for a specific visitor (for timesVisited).
          */
         @Query("SELECT COUNT(a) FROM Appointment a WHERE a.visitorId = :visitorId " +

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/datalayer/dto/AppointmentRequestDTO.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/datalayer/dto/AppointmentRequestDTO.java
@@ -12,5 +12,6 @@ public record AppointmentRequestDTO(
         LocalTime startTime,
         LocalTime endTime,
         String message,
-        UUID propertyId) {
+        UUID propertyId,
+        UUID visitorId) {
 }

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/datalayer/dto/AppointmentResponseDTO.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/datalayer/dto/AppointmentResponseDTO.java
@@ -30,5 +30,7 @@ public record AppointmentResponseDTO(
         UUID cancelledBy,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
-        UUID propertyId) {
+        UUID propertyId,
+        Integer numberOfVisitors,
+        UUID visitorId) {
 }

--- a/backend/src/main/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentController.java
+++ b/backend/src/main/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentController.java
@@ -202,6 +202,27 @@ public class AppointmentController {
         return ResponseEntity.ok(updatedAppointment);
     }
 
+    /**
+     * Update the visitor count for an open_house or private_showing appointment.
+     */
+    @PatchMapping("/{appointmentId}/visitor-count")
+    @PreAuthorize("hasAnyRole('BROKER', 'ADMIN')")
+    public ResponseEntity<AppointmentResponseDTO> updateVisitorCount(
+            @PathVariable UUID appointmentId,
+            @RequestBody java.util.Map<String, Integer> body,
+            @RequestHeader(value = "x-broker-id", required = false) String brokerHeader,
+            @AuthenticationPrincipal Jwt jwt,
+            HttpServletRequest request) {
+
+        UUID userId = UserContextUtils.resolveUserId(request, brokerHeader);
+        Integer numberOfVisitors = body.get("numberOfVisitors");
+        if (numberOfVisitors == null) {
+            throw new BadRequestException("numberOfVisitors is required");
+        }
+        AppointmentResponseDTO updated = appointmentService.updateVisitorCount(appointmentId, numberOfVisitors, userId);
+        return ResponseEntity.ok(updated);
+    }
+
     @GetMapping("/client/{clientId}")
     @PreAuthorize("hasAnyRole('BROKER', 'ADMIN')")
     public ResponseEntity<List<AppointmentResponseDTO>> getAppointmentsForClient(

--- a/backend/src/main/java/com/example/courtierprobackend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/courtierprobackend/config/SecurityConfig.java
@@ -109,6 +109,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/transactions/*/search-criteria").hasAnyRole("BROKER", "CLIENT")
                         .requestMatchers(HttpMethod.PUT, "/transactions/*/search-criteria").hasAnyRole("BROKER", "CLIENT")
                         .requestMatchers(HttpMethod.DELETE, "/transactions/*/search-criteria").hasAnyRole("BROKER", "CLIENT")
+                        // Visitor read access - accessible to both broker and client
+                        .requestMatchers(HttpMethod.GET, "/transactions/*/visitors").hasAnyRole("BROKER", "CLIENT")
                         // Catch-all for other transaction endpoints - requires broker role
                         .requestMatchers("/transactions/**").hasRole("BROKER")
 

--- a/backend/src/main/java/com/example/courtierprobackend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/courtierprobackend/config/SecurityConfig.java
@@ -109,8 +109,11 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/transactions/*/search-criteria").hasAnyRole("BROKER", "CLIENT")
                         .requestMatchers(HttpMethod.PUT, "/transactions/*/search-criteria").hasAnyRole("BROKER", "CLIENT")
                         .requestMatchers(HttpMethod.DELETE, "/transactions/*/search-criteria").hasAnyRole("BROKER", "CLIENT")
-                        // Visitor read access - accessible to both broker and client
-                        .requestMatchers(HttpMethod.GET, "/transactions/*/visitors").hasAnyRole("BROKER", "CLIENT")
+                        // Visitor endpoints - read accessible to broker, client and admin; write restricted to broker and admin
+                        .requestMatchers(HttpMethod.GET, "/transactions/*/visitors").hasAnyRole("BROKER", "CLIENT", "ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/transactions/*/visitors").hasAnyRole("BROKER", "ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/transactions/*/visitors/*").hasAnyRole("BROKER", "ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/transactions/*/visitors/*").hasAnyRole("BROKER", "ADMIN")
                         // Catch-all for other transaction endpoints - requires broker role
                         .requestMatchers("/transactions/**").hasRole("BROKER")
 

--- a/backend/src/main/java/com/example/courtierprobackend/email/EmailService.java
+++ b/backend/src/main/java/com/example/courtierprobackend/email/EmailService.java
@@ -749,7 +749,7 @@ public class EmailService {
         if (title == null) return isFrench ? "Rendez-vous" : "Appointment";
         return switch (title.toLowerCase()) {
             case "house_visit" -> isFrench ? "Visite de maison" : "House Visit";
-            case "open_house" -> isFrench ? "Journée portes ouvertes" : "Open House";
+            case "open_house" -> isFrench ? "Portes ouvertes" : "Open House";
             case "private_showing" -> isFrench ? "Visite privée" : "Private Showing";
             case "inspection" -> isFrench ? "Inspection" : "Inspection";
             case "notary" -> isFrench ? "Notaire" : "Notary";
@@ -768,7 +768,7 @@ public class EmailService {
             case "CONFIRMED" -> isFrench ? "Confirmé" : "Confirmed";
             case "DECLINED" -> isFrench ? "Refusé" : "Declined";
             case "CANCELLED" -> isFrench ? "Annulé" : "Cancelled";
-            case "RESCHEDULED" -> isFrench ? "Reporté" : "Rescheduled";
+
             case "PROPOSED" -> isFrench ? "Proposé" : "Proposed";
             default -> status;
         };

--- a/backend/src/main/java/com/example/courtierprobackend/email/EmailService.java
+++ b/backend/src/main/java/com/example/courtierprobackend/email/EmailService.java
@@ -749,6 +749,8 @@ public class EmailService {
         if (title == null) return isFrench ? "Rendez-vous" : "Appointment";
         return switch (title.toLowerCase()) {
             case "house_visit" -> isFrench ? "Visite de maison" : "House Visit";
+            case "open_house" -> isFrench ? "Journée portes ouvertes" : "Open House";
+            case "private_showing" -> isFrench ? "Visite privée" : "Private Showing";
             case "inspection" -> isFrench ? "Inspection" : "Inspection";
             case "notary" -> isFrench ? "Notaire" : "Notary";
             case "consultation" -> isFrench ? "Consultation" : "Consultation";
@@ -757,6 +759,18 @@ public class EmailService {
             case "property viewing" -> isFrench ? "Visite de propriété" : "Property Viewing";
             case "other" -> isFrench ? "Autre" : "Other";
             default -> title;
+        };
+    }
+
+    String translateAppointmentStatus(String status, boolean isFrench) {
+        if (status == null) return "";
+        return switch (status.toUpperCase()) {
+            case "CONFIRMED" -> isFrench ? "Confirmé" : "Confirmed";
+            case "DECLINED" -> isFrench ? "Refusé" : "Declined";
+            case "CANCELLED" -> isFrench ? "Annulé" : "Cancelled";
+            case "RESCHEDULED" -> isFrench ? "Reporté" : "Rescheduled";
+            case "PROPOSED" -> isFrench ? "Proposé" : "Proposed";
+            default -> status;
         };
     }
 
@@ -803,13 +817,15 @@ public class EmailService {
             return;
 
         boolean isFrench = "fr".equalsIgnoreCase(language);
-        String subject = isFrench ? "Mise à jour du rendez-vous: " + status : "Appointment Update: " + status;
+        String translatedTitle = translateAppointmentTitle(appointment.getTitle(), isFrench);
+        String translatedStatus = translateAppointmentStatus(status, isFrench);
+        String subject = isFrench ? "Mise à jour du rendez-vous: " + translatedStatus : "Appointment Update: " + translatedStatus;
         String body = isFrench
                 ? "Bonjour {{name}}, le statut de votre rendez-vous \"{{title}}\" pour {{date}} est maintenant: {{status}}. Raison: {{reason}}"
                 : "Hello {{name}}, the status of your appointment \"{{title}}\" for {{date}} is now: {{status}}. Reason: {{reason}}";
 
         java.util.Map<String, String> extraVars = new java.util.HashMap<>();
-        extraVars.put("status", status);
+        extraVars.put("status", translatedStatus);
         extraVars.put("reason", reason);
 
         sendAppointmentEmail(toEmail, subject, body, recipientName, appointment, language, extraVars);

--- a/backend/src/main/java/com/example/courtierprobackend/transactions/businesslayer/TransactionService.java
+++ b/backend/src/main/java/com/example/courtierprobackend/transactions/businesslayer/TransactionService.java
@@ -62,6 +62,17 @@ public interface TransactionService {
     // House visit statistics (for buyer transactions)
     int getHouseVisitCount(UUID transactionId, UUID userId);
 
+    // Visitors (for seller transactions)
+    List<com.example.courtierprobackend.transactions.datalayer.dto.VisitorResponseDTO> getVisitors(UUID transactionId, UUID userId);
+
+    com.example.courtierprobackend.transactions.datalayer.dto.VisitorResponseDTO addVisitor(UUID transactionId,
+            com.example.courtierprobackend.transactions.datalayer.dto.VisitorRequestDTO dto, UUID brokerId);
+
+    com.example.courtierprobackend.transactions.datalayer.dto.VisitorResponseDTO updateVisitor(UUID transactionId, UUID visitorId,
+            com.example.courtierprobackend.transactions.datalayer.dto.VisitorRequestDTO dto, UUID brokerId);
+
+    void removeVisitor(UUID transactionId, UUID visitorId, UUID brokerId);
+
     // Properties (for buyer transactions)
     List<PropertyResponseDTO> getProperties(UUID transactionId, UUID userId, boolean isBroker);
 

--- a/backend/src/main/java/com/example/courtierprobackend/transactions/datalayer/Visitor.java
+++ b/backend/src/main/java/com/example/courtierprobackend/transactions/datalayer/Visitor.java
@@ -1,0 +1,59 @@
+package com.example.courtierprobackend.transactions.datalayer;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Represents a visitor (potential buyer) who visits a property
+ * in a sell-side transaction via open houses or private showings.
+ */
+@Entity
+@Table(name = "visitors")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Visitor {
+
+    @Id
+    @Column(name = "visitor_id", nullable = false, unique = true)
+    private UUID visitorId;
+
+    @Column(name = "transaction_id", nullable = false)
+    private UUID transactionId;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String email;
+
+    @Column(name = "phone_number")
+    private String phoneNumber;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (visitorId == null) {
+            visitorId = UUID.randomUUID();
+        }
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+        if (updatedAt == null) {
+            updatedAt = LocalDateTime.now();
+        }
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/example/courtierprobackend/transactions/datalayer/dto/TransactionResponseDTO.java
+++ b/backend/src/main/java/com/example/courtierprobackend/transactions/datalayer/dto/TransactionResponseDTO.java
@@ -29,6 +29,8 @@ public class TransactionResponseDTO {
     private String archivedAt;
     private String notes;
     private Integer houseVisitCount;
+    private Integer totalShowings;
+    private Integer totalVisitors;
 }
 
 

--- a/backend/src/main/java/com/example/courtierprobackend/transactions/datalayer/dto/VisitorRequestDTO.java
+++ b/backend/src/main/java/com/example/courtierprobackend/transactions/datalayer/dto/VisitorRequestDTO.java
@@ -1,0 +1,7 @@
+package com.example.courtierprobackend.transactions.datalayer.dto;
+
+public record VisitorRequestDTO(
+        String name,
+        String email,
+        String phoneNumber) {
+}

--- a/backend/src/main/java/com/example/courtierprobackend/transactions/datalayer/dto/VisitorResponseDTO.java
+++ b/backend/src/main/java/com/example/courtierprobackend/transactions/datalayer/dto/VisitorResponseDTO.java
@@ -1,0 +1,15 @@
+package com.example.courtierprobackend.transactions.datalayer.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record VisitorResponseDTO(
+        UUID visitorId,
+        UUID transactionId,
+        String name,
+        String email,
+        String phoneNumber,
+        int timesVisited,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt) {
+}

--- a/backend/src/main/java/com/example/courtierprobackend/transactions/datalayer/repositories/VisitorRepository.java
+++ b/backend/src/main/java/com/example/courtierprobackend/transactions/datalayer/repositories/VisitorRepository.java
@@ -1,0 +1,19 @@
+package com.example.courtierprobackend.transactions.datalayer.repositories;
+
+import com.example.courtierprobackend.transactions.datalayer.Visitor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface VisitorRepository extends JpaRepository<Visitor, UUID> {
+
+    Optional<Visitor> findByVisitorId(UUID visitorId);
+
+    List<Visitor> findByTransactionIdOrderByNameAsc(UUID transactionId);
+
+    int countByTransactionId(UUID transactionId);
+}

--- a/backend/src/main/java/com/example/courtierprobackend/transactions/presentationlayer/TransactionController.java
+++ b/backend/src/main/java/com/example/courtierprobackend/transactions/presentationlayer/TransactionController.java
@@ -314,6 +314,53 @@ public class TransactionController {
         return ResponseEntity.ok(service.getParticipants(transactionId, userId));
     }
 
+    // ==================== VISITOR ENDPOINTS (Sell-Side) ====================
+
+    @GetMapping("/{transactionId}/visitors")
+    @PreAuthorize("hasAnyRole('BROKER', 'ADMIN', 'CLIENT')")
+    public ResponseEntity<List<com.example.courtierprobackend.transactions.datalayer.dto.VisitorResponseDTO>> getVisitors(
+            @PathVariable UUID transactionId,
+            @RequestHeader(value = "x-broker-id", required = false) String brokerHeader,
+            HttpServletRequest request) {
+        UUID userId = UserContextUtils.resolveUserId(request, brokerHeader);
+        return ResponseEntity.ok(service.getVisitors(transactionId, userId));
+    }
+
+    @PostMapping("/{transactionId}/visitors")
+    @PreAuthorize("hasAnyRole('BROKER', 'ADMIN')")
+    public ResponseEntity<com.example.courtierprobackend.transactions.datalayer.dto.VisitorResponseDTO> addVisitor(
+            @PathVariable UUID transactionId,
+            @RequestBody com.example.courtierprobackend.transactions.datalayer.dto.VisitorRequestDTO dto,
+            @RequestHeader(value = "x-broker-id", required = false) String brokerHeader,
+            HttpServletRequest request) {
+        UUID brokerId = UserContextUtils.resolveUserId(request, brokerHeader);
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.addVisitor(transactionId, dto, brokerId));
+    }
+
+    @PutMapping("/{transactionId}/visitors/{visitorId}")
+    @PreAuthorize("hasAnyRole('BROKER', 'ADMIN')")
+    public ResponseEntity<com.example.courtierprobackend.transactions.datalayer.dto.VisitorResponseDTO> updateVisitor(
+            @PathVariable UUID transactionId,
+            @PathVariable UUID visitorId,
+            @RequestBody com.example.courtierprobackend.transactions.datalayer.dto.VisitorRequestDTO dto,
+            @RequestHeader(value = "x-broker-id", required = false) String brokerHeader,
+            HttpServletRequest request) {
+        UUID brokerId = UserContextUtils.resolveUserId(request, brokerHeader);
+        return ResponseEntity.ok(service.updateVisitor(transactionId, visitorId, dto, brokerId));
+    }
+
+    @DeleteMapping("/{transactionId}/visitors/{visitorId}")
+    @PreAuthorize("hasAnyRole('BROKER', 'ADMIN')")
+    public ResponseEntity<Void> removeVisitor(
+            @PathVariable UUID transactionId,
+            @PathVariable UUID visitorId,
+            @RequestHeader(value = "x-broker-id", required = false) String brokerHeader,
+            HttpServletRequest request) {
+        UUID brokerId = UserContextUtils.resolveUserId(request, brokerHeader);
+        service.removeVisitor(transactionId, visitorId, brokerId);
+        return ResponseEntity.noContent().build();
+    }
+
     // ==================== PROPERTY ENDPOINTS ====================
 
     @GetMapping("/{transactionId}/properties")

--- a/backend/src/main/resources/migration/V3__selling_house_visits.sql
+++ b/backend/src/main/resources/migration/V3__selling_house_visits.sql
@@ -1,0 +1,28 @@
+-- =============================================================================
+-- V3: Selling House Visits (CP-28)
+-- Add visitors table for sell-side transactions and visitor tracking on appointments
+-- =============================================================================
+
+-- Visitors table for sell-side transactions
+CREATE TABLE IF NOT EXISTS visitors (
+    visitor_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    transaction_id UUID NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255),
+    phone_number VARCHAR(50),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_visitors_transaction FOREIGN KEY (transaction_id)
+        REFERENCES transactions(transaction_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_visitors_transaction_id ON visitors(transaction_id);
+
+-- Add visitor tracking fields to appointments
+ALTER TABLE appointments ADD COLUMN number_of_visitors INTEGER;
+ALTER TABLE appointments ADD COLUMN visitor_id UUID;
+
+ALTER TABLE appointments ADD CONSTRAINT fk_appointments_visitor
+    FOREIGN KEY (visitor_id) REFERENCES visitors(visitor_id) ON DELETE SET NULL;
+
+CREATE INDEX idx_appointments_visitor_id ON appointments(visitor_id);

--- a/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceCoverageTest.java
+++ b/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceCoverageTest.java
@@ -57,6 +57,7 @@ class AppointmentServiceCoverageTest {
     @Mock private NotificationService notificationService;
     @Mock private TransactionParticipantRepository transactionParticipantRepository;
     @Mock private PropertyRepository propertyRepository;
+    @Mock private com.example.courtierprobackend.transactions.datalayer.repositories.VisitorRepository visitorRepository;
 
     @InjectMocks
     private AppointmentServiceImpl appointmentService;
@@ -111,7 +112,8 @@ class AppointmentServiceCoverageTest {
                 LocalTime.of(10, 0),
                 LocalTime.of(11, 0),
                 "Note",
-                propertyId
+                propertyId,
+                null
         );
 
         Transaction tx = new Transaction();
@@ -138,7 +140,8 @@ class AppointmentServiceCoverageTest {
                 LocalTime.of(10, 0),
                 LocalTime.of(11, 0),
                 "Note",
-                propertyId
+                propertyId,
+                null
         );
 
         Transaction tx = new Transaction();
@@ -171,6 +174,7 @@ class AppointmentServiceCoverageTest {
                 LocalTime.of(10, 0),
                 LocalTime.of(11, 0),
                 "Note",
+                null,
                 null
         );
 

--- a/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImplAccessControlTest.java
+++ b/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImplAccessControlTest.java
@@ -44,6 +44,8 @@ public class AppointmentServiceImplAccessControlTest {
     private com.example.courtierprobackend.audit.timeline_audit.businesslayer.TimelineService timelineService;
     @Mock
     private com.example.courtierprobackend.transactions.datalayer.repositories.PropertyRepository propertyRepository;
+    @Mock
+    private com.example.courtierprobackend.transactions.datalayer.repositories.VisitorRepository visitorRepository;
 
     @BeforeEach
     void setUp() {
@@ -57,7 +59,8 @@ public class AppointmentServiceImplAccessControlTest {
                 timelineService,
                 notificationService,
                 transactionParticipantRepository,
-                propertyRepository);
+                propertyRepository,
+                visitorRepository);
         transactionId = UUID.randomUUID();
         brokerId = UUID.randomUUID();
         clientId = UUID.randomUUID();

--- a/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImplTest.java
+++ b/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImplTest.java
@@ -70,13 +70,17 @@ class AppointmentServiceImplTest {
         @Mock
         private com.example.courtierprobackend.transactions.datalayer.repositories.PropertyRepository propertyRepository;
 
+        @Mock
+        private com.example.courtierprobackend.transactions.datalayer.repositories.VisitorRepository visitorRepository;
+
         @BeforeEach
         void setUp() {
                 appointmentService = new AppointmentServiceImpl(appointmentRepository, userAccountRepository,
                                 transactionRepository, appointmentAuditService, emailService, timelineService,
                                 notificationService,
                                 transactionParticipantRepository,
-                                propertyRepository);
+                                propertyRepository,
+                                visitorRepository);
                 brokerId = UUID.randomUUID();
                 clientId = UUID.randomUUID();
                 transactionId = UUID.randomUUID();
@@ -837,7 +841,7 @@ class AppointmentServiceImplTest {
                 UUID requesterId = brokerId;
                 com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO request = new com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO(
                                 transactionId, "Property Viewing", null, java.time.LocalDate.now().plusDays(1),
-                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Let's view this", null);
+                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Let's view this", null, null);
 
                 Transaction transaction = new Transaction();
                 transaction.setTransactionId(transactionId);
@@ -869,7 +873,7 @@ class AppointmentServiceImplTest {
                 UUID requesterId = clientId;
                 com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO request = new com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO(
                                 transactionId, "Property Viewing", null, java.time.LocalDate.now().plusDays(1),
-                                java.time.LocalTime.of(14, 0), java.time.LocalTime.of(15, 0), "Can we meet?", null);
+                                java.time.LocalTime.of(14, 0), java.time.LocalTime.of(15, 0), "Can we meet?", null, null);
 
                 Transaction transaction = new Transaction();
                 transaction.setTransactionId(transactionId);
@@ -898,7 +902,7 @@ class AppointmentServiceImplTest {
                 // Arrange
                 com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO request = new com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO(
                                 transactionId, "Other", "Custom Title", java.time.LocalDate.now().plusDays(1),
-                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Details", null);
+                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Details", null, null);
 
                 Transaction transaction = new Transaction();
                 transaction.setTransactionId(transactionId);
@@ -925,7 +929,7 @@ class AppointmentServiceImplTest {
                 // Arrange
                 com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO request = new com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO(
                                 transactionId, "Other", "", java.time.LocalDate.now().plusDays(1), // empty title
-                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Details", null);
+                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Details", null, null);
 
                 Transaction transaction = new Transaction();
                 transaction.setTransactionId(transactionId);
@@ -952,7 +956,7 @@ class AppointmentServiceImplTest {
                 // Arrange
                 com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO request = new com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO(
                                 transactionId, "Type", "Title", java.time.LocalDate.now(),
-                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Msg", null);
+                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Msg", null, null);
 
                 when(transactionRepository.findByTransactionId(transactionId)).thenReturn(Optional.empty());
 
@@ -967,7 +971,7 @@ class AppointmentServiceImplTest {
                 // Arrange
                 com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO request = new com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO(
                                 transactionId, "Type", "Title", java.time.LocalDate.now().plusDays(1),
-                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Msg", null);
+                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Msg", null, null);
 
                 Transaction transaction = new Transaction();
                 transaction.setTransactionId(transactionId);
@@ -988,7 +992,7 @@ class AppointmentServiceImplTest {
                 // Arrange
                 com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO request = new com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO(
                                 transactionId, "Type", "Title", java.time.LocalDate.now(),
-                                java.time.LocalTime.of(12, 0), java.time.LocalTime.of(11, 0), "End before start", null);
+                                java.time.LocalTime.of(12, 0), java.time.LocalTime.of(11, 0), "End before start", null, null);
 
                 Transaction transaction = new Transaction();
                 transaction.setTransactionId(transactionId);
@@ -1040,7 +1044,7 @@ class AppointmentServiceImplTest {
         void requestAppointment_startTimeNotInFuture_throwsIllegalArgumentException() {
                 com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO request = new com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO(
                                 transactionId, "Type", "Title", java.time.LocalDate.now().minusDays(1),
-                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Past date", null);
+                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Past date", null, null);
                 Transaction transaction = new Transaction();
                 transaction.setTransactionId(transactionId);
                 transaction.setBrokerId(brokerId);
@@ -1099,7 +1103,7 @@ class AppointmentServiceImplTest {
         void requestAppointment_missingBrokerId_throwsIllegalStateException() {
                 com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO request = new com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO(
                                 transactionId, "Type", "Title", java.time.LocalDate.now().plusDays(1),
-                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Msg", null);
+                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Msg", null, null);
                 Transaction transaction = new Transaction();
                 transaction.setTransactionId(transactionId);
                 transaction.setBrokerId(null); // missing brokerId
@@ -1114,7 +1118,7 @@ class AppointmentServiceImplTest {
         void requestAppointment_missingClientId_throwsIllegalStateException() {
                 com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO request = new com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO(
                                 transactionId, "Type", "Title", java.time.LocalDate.now().plusDays(1),
-                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Msg", null);
+                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Msg", null, null);
                 Transaction transaction = new Transaction();
                 transaction.setTransactionId(transactionId);
                 transaction.setBrokerId(brokerId);
@@ -1191,7 +1195,7 @@ class AppointmentServiceImplTest {
                 UUID propertyId = UUID.randomUUID();
                 com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO request = new com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO(
                                 transactionId, "house_visit", null, java.time.LocalDate.now().plusDays(1),
-                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Visit", propertyId);
+                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Visit", propertyId, null);
                 Transaction transaction = new Transaction();
                 transaction.setTransactionId(transactionId);
                 transaction.setBrokerId(brokerId);
@@ -1208,7 +1212,7 @@ class AppointmentServiceImplTest {
         void requestAppointment_houseVisit_missingPropertyId_throwsIllegalArgumentException() {
                 com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO request = new com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO(
                                 transactionId, "house_visit", null, java.time.LocalDate.now().plusDays(1),
-                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Visit", null);
+                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Visit", null, null);
                 Transaction transaction = new Transaction();
                 transaction.setTransactionId(transactionId);
                 transaction.setBrokerId(brokerId);
@@ -1226,7 +1230,7 @@ class AppointmentServiceImplTest {
                 UUID propertyId = UUID.randomUUID();
                 com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO request = new com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO(
                                 transactionId, "house_visit", null, java.time.LocalDate.now().plusDays(1),
-                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Visit", propertyId);
+                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Visit", propertyId, null);
                 Transaction transaction = new Transaction();
                 transaction.setTransactionId(transactionId);
                 transaction.setBrokerId(brokerId);
@@ -1256,6 +1260,239 @@ class AppointmentServiceImplTest {
                 assertThat(result).isNotNull();
                 assertThat(result.propertyId()).isEqualTo(propertyId);
                 assertThat(result.title()).isEqualTo("house_visit");
+        }
+
+        // ========== Open House / Private Showing requestAppointment Tests ==========
+
+        @Test
+        void requestAppointment_openHouse_sellSide_success() {
+                com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO request = new com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO(
+                                transactionId, "open_house", null, java.time.LocalDate.now().plusDays(1),
+                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Open house event", null, null);
+                Transaction transaction = new Transaction();
+                transaction.setTransactionId(transactionId);
+                transaction.setBrokerId(brokerId);
+                transaction.setClientId(clientId);
+                transaction.setSide(com.example.courtierprobackend.transactions.datalayer.enums.TransactionSide.SELL_SIDE);
+
+                when(transactionRepository.findByTransactionId(transactionId)).thenReturn(Optional.of(transaction));
+                when(appointmentRepository.save(any(Appointment.class))).thenAnswer(i -> {
+                        Appointment a = (Appointment) i.getArguments()[0];
+                        a.setAppointmentId(UUID.randomUUID());
+                        a.setCreatedAt(LocalDateTime.now());
+                        a.setUpdatedAt(LocalDateTime.now());
+                        return a;
+                });
+                mockUserAccounts();
+
+                AppointmentResponseDTO result = appointmentService.requestAppointment(request, brokerId);
+
+                assertThat(result).isNotNull();
+                assertThat(result.title()).isEqualTo("open_house");
+                assertThat(result.numberOfVisitors()).isNull(); // not set until after event
+        }
+
+        @Test
+        void requestAppointment_openHouse_buySide_throwsIllegalArgument() {
+                com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO request = new com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO(
+                                transactionId, "open_house", null, java.time.LocalDate.now().plusDays(1),
+                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Open house", null, null);
+                Transaction transaction = new Transaction();
+                transaction.setTransactionId(transactionId);
+                transaction.setBrokerId(brokerId);
+                transaction.setClientId(clientId);
+                transaction.setSide(com.example.courtierprobackend.transactions.datalayer.enums.TransactionSide.BUY_SIDE);
+
+                when(transactionRepository.findByTransactionId(transactionId)).thenReturn(Optional.of(transaction));
+
+                assertThatThrownBy(() -> appointmentService.requestAppointment(request, brokerId))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("sell-side transactions");
+        }
+
+        @Test
+        void requestAppointment_privateShowing_sellSide_success() {
+                com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO request = new com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO(
+                                transactionId, "private_showing", null, java.time.LocalDate.now().plusDays(1),
+                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Showing", null, null);
+                Transaction transaction = new Transaction();
+                transaction.setTransactionId(transactionId);
+                transaction.setBrokerId(brokerId);
+                transaction.setClientId(clientId);
+                transaction.setSide(com.example.courtierprobackend.transactions.datalayer.enums.TransactionSide.SELL_SIDE);
+
+                when(transactionRepository.findByTransactionId(transactionId)).thenReturn(Optional.of(transaction));
+                when(appointmentRepository.save(any(Appointment.class))).thenAnswer(i -> {
+                        Appointment a = (Appointment) i.getArguments()[0];
+                        a.setAppointmentId(UUID.randomUUID());
+                        a.setCreatedAt(LocalDateTime.now());
+                        a.setUpdatedAt(LocalDateTime.now());
+                        return a;
+                });
+                mockUserAccounts();
+
+                AppointmentResponseDTO result = appointmentService.requestAppointment(request, brokerId);
+
+                assertThat(result).isNotNull();
+                assertThat(result.title()).isEqualTo("private_showing");
+                assertThat(result.numberOfVisitors()).isEqualTo(1); // default for private showing
+        }
+
+        @Test
+        void requestAppointment_privateShowing_withVisitor_success() {
+                UUID visitorId = UUID.randomUUID();
+                com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO request = new com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO(
+                                transactionId, "private_showing", null, java.time.LocalDate.now().plusDays(1),
+                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Showing", null, visitorId);
+                Transaction transaction = new Transaction();
+                transaction.setTransactionId(transactionId);
+                transaction.setBrokerId(brokerId);
+                transaction.setClientId(clientId);
+                transaction.setSide(com.example.courtierprobackend.transactions.datalayer.enums.TransactionSide.SELL_SIDE);
+
+                com.example.courtierprobackend.transactions.datalayer.Visitor visitor = com.example.courtierprobackend.transactions.datalayer.Visitor.builder()
+                                .visitorId(visitorId)
+                                .transactionId(transactionId)
+                                .name("Test Visitor")
+                                .build();
+
+                when(transactionRepository.findByTransactionId(transactionId)).thenReturn(Optional.of(transaction));
+                when(visitorRepository.findByVisitorId(visitorId)).thenReturn(Optional.of(visitor));
+                when(appointmentRepository.save(any(Appointment.class))).thenAnswer(i -> {
+                        Appointment a = (Appointment) i.getArguments()[0];
+                        a.setAppointmentId(UUID.randomUUID());
+                        a.setCreatedAt(LocalDateTime.now());
+                        a.setUpdatedAt(LocalDateTime.now());
+                        return a;
+                });
+                mockUserAccounts();
+
+                AppointmentResponseDTO result = appointmentService.requestAppointment(request, brokerId);
+
+                assertThat(result).isNotNull();
+                assertThat(result.visitorId()).isEqualTo(visitorId);
+                assertThat(result.numberOfVisitors()).isEqualTo(1);
+        }
+
+        @Test
+        void requestAppointment_privateShowing_visitorNotInTransaction_throws() {
+                UUID visitorId = UUID.randomUUID();
+                UUID otherTxId = UUID.randomUUID();
+                com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO request = new com.example.courtierprobackend.appointments.datalayer.dto.AppointmentRequestDTO(
+                                transactionId, "private_showing", null, java.time.LocalDate.now().plusDays(1),
+                                java.time.LocalTime.of(10, 0), java.time.LocalTime.of(11, 0), "Showing", null, visitorId);
+                Transaction transaction = new Transaction();
+                transaction.setTransactionId(transactionId);
+                transaction.setBrokerId(brokerId);
+                transaction.setClientId(clientId);
+                transaction.setSide(com.example.courtierprobackend.transactions.datalayer.enums.TransactionSide.SELL_SIDE);
+
+                com.example.courtierprobackend.transactions.datalayer.Visitor visitor = com.example.courtierprobackend.transactions.datalayer.Visitor.builder()
+                                .visitorId(visitorId)
+                                .transactionId(otherTxId) // different transaction
+                                .name("Test Visitor")
+                                .build();
+
+                when(transactionRepository.findByTransactionId(transactionId)).thenReturn(Optional.of(transaction));
+                when(visitorRepository.findByVisitorId(visitorId)).thenReturn(Optional.of(visitor));
+
+                assertThatThrownBy(() -> appointmentService.requestAppointment(request, brokerId))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("Visitor does not belong to this transaction");
+        }
+
+        // ========== updateVisitorCount Tests ==========
+
+        @Test
+        void updateVisitorCount_openHouse_afterEvent_success() {
+                UUID appointmentId = UUID.randomUUID();
+                Appointment apt = createTestAppointment();
+                apt.setAppointmentId(appointmentId);
+                apt.setTitle("open_house");
+                apt.setStatus(AppointmentStatus.CONFIRMED);
+                apt.setFromDateTime(LocalDateTime.now().minusHours(3));
+                apt.setToDateTime(LocalDateTime.now().minusHours(2)); // event concluded
+
+                when(appointmentRepository.findByAppointmentIdAndDeletedAtIsNull(appointmentId))
+                                .thenReturn(Optional.of(apt));
+                when(appointmentRepository.save(any(Appointment.class))).thenAnswer(i -> i.getArguments()[0]);
+                mockUserAccounts();
+
+                AppointmentResponseDTO result = appointmentService.updateVisitorCount(appointmentId, 15, brokerId);
+
+                assertThat(result.numberOfVisitors()).isEqualTo(15);
+        }
+
+        @Test
+        void updateVisitorCount_openHouse_beforeEvent_throws() {
+                UUID appointmentId = UUID.randomUUID();
+                Appointment apt = createTestAppointment();
+                apt.setAppointmentId(appointmentId);
+                apt.setTitle("open_house");
+                apt.setStatus(AppointmentStatus.CONFIRMED);
+                apt.setFromDateTime(LocalDateTime.now().plusHours(1));
+                apt.setToDateTime(LocalDateTime.now().plusHours(2)); // event not concluded
+
+                when(appointmentRepository.findByAppointmentIdAndDeletedAtIsNull(appointmentId))
+                                .thenReturn(Optional.of(apt));
+
+                assertThatThrownBy(() -> appointmentService.updateVisitorCount(appointmentId, 15, brokerId))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("after the event concludes");
+        }
+
+        @Test
+        void updateVisitorCount_privateShowing_success() {
+                UUID appointmentId = UUID.randomUUID();
+                Appointment apt = createTestAppointment();
+                apt.setAppointmentId(appointmentId);
+                apt.setTitle("private_showing");
+                apt.setStatus(AppointmentStatus.CONFIRMED);
+                apt.setFromDateTime(LocalDateTime.now().minusHours(3));
+                apt.setToDateTime(LocalDateTime.now().minusHours(2));
+
+                when(appointmentRepository.findByAppointmentIdAndDeletedAtIsNull(appointmentId))
+                                .thenReturn(Optional.of(apt));
+                when(appointmentRepository.save(any(Appointment.class))).thenAnswer(i -> i.getArguments()[0]);
+                mockUserAccounts();
+
+                AppointmentResponseDTO result = appointmentService.updateVisitorCount(appointmentId, 2, brokerId);
+
+                assertThat(result.numberOfVisitors()).isEqualTo(2);
+        }
+
+        @Test
+        void updateVisitorCount_wrongType_throws() {
+                UUID appointmentId = UUID.randomUUID();
+                Appointment apt = createTestAppointment();
+                apt.setAppointmentId(appointmentId);
+                apt.setTitle("meeting"); // not open_house or private_showing
+                apt.setStatus(AppointmentStatus.CONFIRMED);
+
+                when(appointmentRepository.findByAppointmentIdAndDeletedAtIsNull(appointmentId))
+                                .thenReturn(Optional.of(apt));
+
+                assertThatThrownBy(() -> appointmentService.updateVisitorCount(appointmentId, 5, brokerId))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("open house or private showing");
+        }
+
+        @Test
+        void updateVisitorCount_notBroker_throwsForbidden() {
+                UUID appointmentId = UUID.randomUUID();
+                Appointment apt = createTestAppointment();
+                apt.setAppointmentId(appointmentId);
+                apt.setTitle("open_house");
+                apt.setFromDateTime(LocalDateTime.now().minusHours(3));
+                apt.setToDateTime(LocalDateTime.now().minusHours(2));
+
+                when(appointmentRepository.findByAppointmentIdAndDeletedAtIsNull(appointmentId))
+                                .thenReturn(Optional.of(apt));
+
+                UUID otherUser = UUID.randomUUID();
+                assertThatThrownBy(() -> appointmentService.updateVisitorCount(appointmentId, 5, otherUser))
+                                .isInstanceOf(ForbiddenException.class)
+                                .hasMessageContaining("Only the broker");
         }
 }
 

--- a/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImplTest.java
+++ b/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImplTest.java
@@ -1413,7 +1413,7 @@ class AppointmentServiceImplTest {
                 apt.setFromDateTime(LocalDateTime.now().minusHours(3));
                 apt.setToDateTime(LocalDateTime.now().minusHours(2)); // event concluded
 
-                when(appointmentRepository.findByAppointmentIdAndDeletedAtIsNull(appointmentId))
+                when(appointmentRepository.findByAppointmentId(appointmentId))
                                 .thenReturn(Optional.of(apt));
                 when(appointmentRepository.save(any(Appointment.class))).thenAnswer(i -> i.getArguments()[0]);
                 mockUserAccounts();
@@ -1433,7 +1433,7 @@ class AppointmentServiceImplTest {
                 apt.setFromDateTime(LocalDateTime.now().plusHours(1));
                 apt.setToDateTime(LocalDateTime.now().plusHours(2)); // event not concluded
 
-                when(appointmentRepository.findByAppointmentIdAndDeletedAtIsNull(appointmentId))
+                when(appointmentRepository.findByAppointmentId(appointmentId))
                                 .thenReturn(Optional.of(apt));
 
                 assertThatThrownBy(() -> appointmentService.updateVisitorCount(appointmentId, 15, brokerId))
@@ -1451,7 +1451,7 @@ class AppointmentServiceImplTest {
                 apt.setFromDateTime(LocalDateTime.now().minusHours(3));
                 apt.setToDateTime(LocalDateTime.now().minusHours(2));
 
-                when(appointmentRepository.findByAppointmentIdAndDeletedAtIsNull(appointmentId))
+                when(appointmentRepository.findByAppointmentId(appointmentId))
                                 .thenReturn(Optional.of(apt));
                 when(appointmentRepository.save(any(Appointment.class))).thenAnswer(i -> i.getArguments()[0]);
                 mockUserAccounts();
@@ -1469,7 +1469,7 @@ class AppointmentServiceImplTest {
                 apt.setTitle("meeting"); // not open_house or private_showing
                 apt.setStatus(AppointmentStatus.CONFIRMED);
 
-                when(appointmentRepository.findByAppointmentIdAndDeletedAtIsNull(appointmentId))
+                when(appointmentRepository.findByAppointmentId(appointmentId))
                                 .thenReturn(Optional.of(apt));
 
                 assertThatThrownBy(() -> appointmentService.updateVisitorCount(appointmentId, 5, brokerId))
@@ -1486,7 +1486,7 @@ class AppointmentServiceImplTest {
                 apt.setFromDateTime(LocalDateTime.now().minusHours(3));
                 apt.setToDateTime(LocalDateTime.now().minusHours(2));
 
-                when(appointmentRepository.findByAppointmentIdAndDeletedAtIsNull(appointmentId))
+                when(appointmentRepository.findByAppointmentId(appointmentId))
                                 .thenReturn(Optional.of(apt));
 
                 UUID otherUser = UUID.randomUUID();
@@ -1503,7 +1503,7 @@ class AppointmentServiceImplTest {
                 apt.setTitle("open_house");
                 apt.setStatus(AppointmentStatus.PROPOSED); // not confirmed
 
-                when(appointmentRepository.findByAppointmentIdAndDeletedAtIsNull(appointmentId))
+                when(appointmentRepository.findByAppointmentId(appointmentId))
                                 .thenReturn(Optional.of(apt));
 
                 assertThatThrownBy(() -> appointmentService.updateVisitorCount(appointmentId, 5, brokerId))

--- a/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImplTest.java
+++ b/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceImplTest.java
@@ -1494,5 +1494,21 @@ class AppointmentServiceImplTest {
                                 .isInstanceOf(ForbiddenException.class)
                                 .hasMessageContaining("Only the broker");
         }
+
+        @Test
+        void updateVisitorCount_notConfirmed_throws() {
+                UUID appointmentId = UUID.randomUUID();
+                Appointment apt = createTestAppointment();
+                apt.setAppointmentId(appointmentId);
+                apt.setTitle("open_house");
+                apt.setStatus(AppointmentStatus.PROPOSED); // not confirmed
+
+                when(appointmentRepository.findByAppointmentIdAndDeletedAtIsNull(appointmentId))
+                                .thenReturn(Optional.of(apt));
+
+                assertThatThrownBy(() -> appointmentService.updateVisitorCount(appointmentId, 5, brokerId))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("confirmed appointments");
+        }
 }
 

--- a/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceNotificationTest.java
+++ b/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/AppointmentServiceNotificationTest.java
@@ -74,13 +74,17 @@ class AppointmentServiceNotificationTest {
         @Mock
         private com.example.courtierprobackend.transactions.datalayer.repositories.PropertyRepository propertyRepository;
 
+        @Mock
+        private com.example.courtierprobackend.transactions.datalayer.repositories.VisitorRepository visitorRepository;
+
         @BeforeEach
         void setUp() {
                 appointmentService = new AppointmentServiceImpl(appointmentRepository, userAccountRepository,
                                 transactionRepository, appointmentAuditService, emailService, timelineService,
                                 notificationService,
                                 transactionParticipantRepository,
-                                propertyRepository);
+                                propertyRepository,
+                                visitorRepository);
 
                 brokerId = UUID.randomUUID();
                 clientId = UUID.randomUUID();
@@ -112,7 +116,7 @@ class AppointmentServiceNotificationTest {
                 // Arrange
                 AppointmentRequestDTO request = new AppointmentRequestDTO(
                                 transactionId, "Viewing", "Notes", LocalDate.now().plusDays(1),
-                                LocalTime.of(10, 0), LocalTime.of(11, 0), "Message", null);
+                                LocalTime.of(10, 0), LocalTime.of(11, 0), "Message", null, null);
 
                 Transaction transaction = new Transaction();
                 transaction.setTransactionId(transactionId);

--- a/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/RescheduleDuplicationTest.java
+++ b/backend/src/test/java/com/example/courtierprobackend/appointments/businesslayer/RescheduleDuplicationTest.java
@@ -84,7 +84,7 @@ public class RescheduleDuplicationTest {
                 // 2. Create Appointment (PROPOSED)
                 AppointmentRequestDTO createReq = new AppointmentRequestDTO(
                                 transactionId, "Property Visit", null, LocalDate.now().plusDays(1), LocalTime.of(10, 0),
-                                LocalTime.of(11, 0), "Note", null);
+                                LocalTime.of(11, 0), "Note", null, null);
                 AppointmentResponseDTO created = appointmentService.requestAppointment(createReq, brokerId);
                 UUID appointmentId = created.appointmentId();
 

--- a/backend/src/test/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentControllerTest.java
+++ b/backend/src/test/java/com/example/courtierprobackend/appointments/presentationlayer/AppointmentControllerTest.java
@@ -72,6 +72,8 @@ class AppointmentControllerTest {
                                 null,
                                 LocalDateTime.now(),
                                 LocalDateTime.now(),
+                                null,
+                                null,
                                 null);
         }
 
@@ -387,6 +389,7 @@ class AppointmentControllerTest {
                                 java.time.LocalTime.of(10, 0),
                                 java.time.LocalTime.of(11, 0),
                                 "Test message",
+                                null,
                                 null);
 
                 AppointmentResponseDTO responseDTO = createTestAppointmentDTO();

--- a/backend/src/test/java/com/example/courtierprobackend/transactions/ConditionLinkingServiceUnitTest.java
+++ b/backend/src/test/java/com/example/courtierprobackend/transactions/ConditionLinkingServiceUnitTest.java
@@ -52,6 +52,7 @@ class ConditionLinkingServiceUnitTest {
     @Mock private DocumentConditionLinkRepository documentConditionLinkRepository;
     @Mock private SearchCriteriaRepository searchCriteriaRepository;
     @Mock private com.example.courtierprobackend.appointments.datalayer.AppointmentRepository appointmentRepository;
+    @Mock private com.example.courtierprobackend.transactions.datalayer.repositories.VisitorRepository visitorRepository;
 
     private TransactionServiceImpl transactionService;
 
@@ -81,7 +82,8 @@ class ConditionLinkingServiceUnitTest {
                 documentRequestRepository,
                 documentConditionLinkRepository,
                 searchCriteriaRepository,
-                appointmentRepository
+                appointmentRepository,
+                visitorRepository
         );
 
         transactionId = UUID.randomUUID();

--- a/backend/src/test/java/com/example/courtierprobackend/transactions/businesslayer/PropertyServiceUnitTest.java
+++ b/backend/src/test/java/com/example/courtierprobackend/transactions/businesslayer/PropertyServiceUnitTest.java
@@ -102,6 +102,9 @@ class PropertyServiceUnitTest {
         @Mock
         private com.example.courtierprobackend.appointments.datalayer.AppointmentRepository appointmentRepository;
 
+        @Mock
+        private com.example.courtierprobackend.transactions.datalayer.repositories.VisitorRepository visitorRepository;
+
         @InjectMocks
         private TransactionServiceImpl service;
 
@@ -122,7 +125,7 @@ class PropertyServiceUnitTest {
                                 offerRepository, conditionRepository,
                                 propertyOfferRepository, offerDocumentRepository, offerRevisionRepository,
                                 objectStorageService, documentRequestRepository, documentConditionLinkRepository,
-                                searchCriteriaRepository, appointmentRepository);
+                                searchCriteriaRepository, appointmentRepository, visitorRepository);
 
                 transactionId = UUID.randomUUID();
                 brokerId = UUID.randomUUID();

--- a/backend/src/test/java/com/example/courtierprobackend/transactions/businesslayer/SearchCriteriaServiceUnitTest.java
+++ b/backend/src/test/java/com/example/courtierprobackend/transactions/businesslayer/SearchCriteriaServiceUnitTest.java
@@ -66,6 +66,7 @@ class SearchCriteriaServiceUnitTest {
     @Mock private DocumentConditionLinkRepository documentConditionLinkRepository;
     @Mock private SearchCriteriaRepository searchCriteriaRepository;
     @Mock private com.example.courtierprobackend.appointments.datalayer.AppointmentRepository appointmentRepository;
+    @Mock private com.example.courtierprobackend.transactions.datalayer.repositories.VisitorRepository visitorRepository;
 
     private TransactionServiceImpl service;
 
@@ -86,7 +87,8 @@ class SearchCriteriaServiceUnitTest {
                 propertyRepository, offerRepository, conditionRepository, propertyOfferRepository,
                 offerDocumentRepository, offerRevisionRepository, objectStorageService,
                 documentRequestRepository, documentConditionLinkRepository, searchCriteriaRepository,
-                appointmentRepository
+                appointmentRepository,
+                visitorRepository
         );
 
         transactionId = UUID.randomUUID();

--- a/backend/src/test/java/com/example/courtierprobackend/transactions/businesslayer/TransactionServiceImplTest.java
+++ b/backend/src/test/java/com/example/courtierprobackend/transactions/businesslayer/TransactionServiceImplTest.java
@@ -112,6 +112,9 @@ class TransactionServiceImplTest {
         @Mock
         private com.example.courtierprobackend.appointments.datalayer.AppointmentRepository appointmentRepository;
 
+        @Mock
+        private com.example.courtierprobackend.transactions.datalayer.repositories.VisitorRepository visitorRepository;
+
         @BeforeEach
         void setup() {
                 transactionService = new TransactionServiceImpl(transactionRepository, pinnedTransactionRepository,
@@ -120,7 +123,7 @@ class TransactionServiceImplTest {
                                 offerRepository, conditionRepository,
                                 propertyOfferRepository, offerDocumentRepository, offerRevisionRepository,
                                 objectStorageService, documentRequestRepository, documentConditionLinkRepository,
-                                searchCriteriaRepository, appointmentRepository);
+                                searchCriteriaRepository, appointmentRepository, visitorRepository);
                 lenient().when(userAccountRepository.findByAuth0UserId(any())).thenReturn(Optional.empty());
         }
 
@@ -7371,5 +7374,267 @@ class TransactionServiceImplTest {
 
                 assertThat(result).isEqualTo("https://s3.example.com/offer-with-filename");
                 verify(objectStorageService).generatePresignedUrl("offer-key", "accepted-offer.pdf");
+        }
+
+        // ========== Visitor CRUD Tests (Sell-Side) ==========
+
+        private Transaction createSellSideTransaction(UUID transactionId, UUID brokerId) {
+                Transaction tx = new Transaction();
+                tx.setTransactionId(transactionId);
+                tx.setBrokerId(brokerId);
+                tx.setClientId(UUID.randomUUID());
+                tx.setSide(TransactionSide.SELL_SIDE);
+                tx.setStatus(TransactionStatus.ACTIVE);
+                return tx;
+        }
+
+        private com.example.courtierprobackend.transactions.datalayer.Visitor createVisitorEntity(
+                        UUID transactionId, String name, String email, String phone) {
+                return com.example.courtierprobackend.transactions.datalayer.Visitor.builder()
+                                .visitorId(UUID.randomUUID())
+                                .transactionId(transactionId)
+                                .name(name)
+                                .email(email)
+                                .phoneNumber(phone)
+                                .createdAt(LocalDateTime.now())
+                                .updatedAt(LocalDateTime.now())
+                                .build();
+        }
+
+        @Test
+        void getVisitors_withValidTransaction_returnsVisitorsWithCounts() {
+                UUID transactionId = UUID.randomUUID();
+                UUID brokerId = UUID.randomUUID();
+                Transaction tx = createSellSideTransaction(transactionId, brokerId);
+
+                when(transactionRepository.findByTransactionId(transactionId)).thenReturn(Optional.of(tx));
+                when(userAccountRepository.findById(brokerId)).thenReturn(Optional.empty());
+                when(participantRepository.findByTransactionId(transactionId)).thenReturn(List.of());
+
+                var visitor1 = createVisitorEntity(transactionId, "Alice", "alice@test.com", "555-0001");
+                var visitor2 = createVisitorEntity(transactionId, "Bob", "bob@test.com", null);
+                when(visitorRepository.findByTransactionIdOrderByNameAsc(transactionId))
+                                .thenReturn(List.of(visitor1, visitor2));
+
+                when(appointmentRepository.countConfirmedShowingsByVisitorIds(any()))
+                                .thenReturn(List.of(
+                                                new Object[] { visitor1.getVisitorId(), 3L },
+                                                new Object[] { visitor2.getVisitorId(), 1L }));
+
+                var result = transactionService.getVisitors(transactionId, brokerId);
+
+                assertThat(result).hasSize(2);
+                assertThat(result.get(0).name()).isEqualTo("Alice");
+                assertThat(result.get(0).timesVisited()).isEqualTo(3);
+                assertThat(result.get(1).name()).isEqualTo("Bob");
+                assertThat(result.get(1).timesVisited()).isEqualTo(1);
+        }
+
+        @Test
+        void getVisitors_withNoVisitors_returnsEmptyList() {
+                UUID transactionId = UUID.randomUUID();
+                UUID brokerId = UUID.randomUUID();
+                Transaction tx = createSellSideTransaction(transactionId, brokerId);
+
+                when(transactionRepository.findByTransactionId(transactionId)).thenReturn(Optional.of(tx));
+                when(userAccountRepository.findById(brokerId)).thenReturn(Optional.empty());
+                when(participantRepository.findByTransactionId(transactionId)).thenReturn(List.of());
+                when(visitorRepository.findByTransactionIdOrderByNameAsc(transactionId)).thenReturn(List.of());
+
+                var result = transactionService.getVisitors(transactionId, brokerId);
+
+                assertThat(result).isEmpty();
+        }
+
+        @Test
+        void getVisitors_withNonExistentTransaction_throwsNotFoundException() {
+                when(transactionRepository.findByTransactionId(any())).thenReturn(Optional.empty());
+
+                assertThatThrownBy(() -> transactionService.getVisitors(UUID.randomUUID(), UUID.randomUUID()))
+                                .isInstanceOf(NotFoundException.class)
+                                .hasMessageContaining("Transaction not found");
+        }
+
+        @Test
+        void addVisitor_withValidData_createsVisitor() {
+                UUID transactionId = UUID.randomUUID();
+                UUID brokerId = UUID.randomUUID();
+                Transaction tx = createSellSideTransaction(transactionId, brokerId);
+
+                when(transactionRepository.findByTransactionId(transactionId)).thenReturn(Optional.of(tx));
+
+                var dto = new com.example.courtierprobackend.transactions.datalayer.dto.VisitorRequestDTO(
+                                "Jane Doe", "jane@test.com", "555-0002");
+
+                when(visitorRepository.save(any(com.example.courtierprobackend.transactions.datalayer.Visitor.class)))
+                                .thenAnswer(invocation -> {
+                                        var v = invocation
+                                                        .getArgument(0,
+                                                                        com.example.courtierprobackend.transactions.datalayer.Visitor.class);
+                                        if (v.getVisitorId() == null)
+                                                v.setVisitorId(UUID.randomUUID());
+                                        if (v.getCreatedAt() == null)
+                                                v.setCreatedAt(LocalDateTime.now());
+                                        if (v.getUpdatedAt() == null)
+                                                v.setUpdatedAt(LocalDateTime.now());
+                                        return v;
+                                });
+
+                var result = transactionService.addVisitor(transactionId, dto, brokerId);
+
+                assertThat(result).isNotNull();
+                assertThat(result.name()).isEqualTo("Jane Doe");
+                assertThat(result.email()).isEqualTo("jane@test.com");
+                assertThat(result.phoneNumber()).isEqualTo("555-0002");
+                assertThat(result.timesVisited()).isEqualTo(0);
+                verify(visitorRepository).save(any(com.example.courtierprobackend.transactions.datalayer.Visitor.class));
+        }
+
+        @Test
+        void addVisitor_withBlankName_throwsIllegalArgumentException() {
+                UUID transactionId = UUID.randomUUID();
+                UUID brokerId = UUID.randomUUID();
+                Transaction tx = createSellSideTransaction(transactionId, brokerId);
+
+                when(transactionRepository.findByTransactionId(transactionId)).thenReturn(Optional.of(tx));
+
+                var dto = new com.example.courtierprobackend.transactions.datalayer.dto.VisitorRequestDTO(
+                                "   ", "email@test.com", null);
+
+                assertThatThrownBy(() -> transactionService.addVisitor(transactionId, dto, brokerId))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("Visitor name is required");
+        }
+
+        @Test
+        void addVisitor_onBuySideTransaction_throwsIllegalArgumentException() {
+                UUID transactionId = UUID.randomUUID();
+                UUID brokerId = UUID.randomUUID();
+                Transaction tx = createSellSideTransaction(transactionId, brokerId);
+                tx.setSide(TransactionSide.BUY_SIDE);
+
+                when(transactionRepository.findByTransactionId(transactionId)).thenReturn(Optional.of(tx));
+
+                var dto = new com.example.courtierprobackend.transactions.datalayer.dto.VisitorRequestDTO(
+                                "Test Visitor", null, null);
+
+                assertThatThrownBy(() -> transactionService.addVisitor(transactionId, dto, brokerId))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("sell-side transactions");
+        }
+
+        @Test
+        void updateVisitor_withValidData_updatesVisitor() {
+                UUID transactionId = UUID.randomUUID();
+                UUID brokerId = UUID.randomUUID();
+                Transaction tx = createSellSideTransaction(transactionId, brokerId);
+
+                var visitor = createVisitorEntity(transactionId, "Old Name", "old@test.com", "555-0000");
+
+                when(transactionRepository.findByTransactionId(transactionId)).thenReturn(Optional.of(tx));
+                when(visitorRepository.findByVisitorId(visitor.getVisitorId())).thenReturn(Optional.of(visitor));
+                when(visitorRepository.save(any(com.example.courtierprobackend.transactions.datalayer.Visitor.class)))
+                                .thenAnswer(invocation -> invocation.getArgument(0));
+                when(appointmentRepository.countConfirmedShowingsByVisitorId(visitor.getVisitorId())).thenReturn(2);
+
+                var dto = new com.example.courtierprobackend.transactions.datalayer.dto.VisitorRequestDTO(
+                                "Updated Name", "updated@test.com", "555-9999");
+
+                var result = transactionService.updateVisitor(transactionId, visitor.getVisitorId(), dto, brokerId);
+
+                assertThat(result.name()).isEqualTo("Updated Name");
+                assertThat(result.email()).isEqualTo("updated@test.com");
+                assertThat(result.phoneNumber()).isEqualTo("555-9999");
+                assertThat(result.timesVisited()).isEqualTo(2);
+        }
+
+        @Test
+        void updateVisitor_withWrongTransaction_throwsForbiddenException() {
+                UUID transactionId = UUID.randomUUID();
+                UUID otherTransactionId = UUID.randomUUID();
+                UUID brokerId = UUID.randomUUID();
+                Transaction tx = createSellSideTransaction(transactionId, brokerId);
+
+                var visitor = createVisitorEntity(otherTransactionId, "Test", null, null);
+
+                when(transactionRepository.findByTransactionId(transactionId)).thenReturn(Optional.of(tx));
+                when(visitorRepository.findByVisitorId(visitor.getVisitorId())).thenReturn(Optional.of(visitor));
+
+                var dto = new com.example.courtierprobackend.transactions.datalayer.dto.VisitorRequestDTO(
+                                "Updated", null, null);
+
+                assertThatThrownBy(
+                                () -> transactionService.updateVisitor(transactionId, visitor.getVisitorId(), dto, brokerId))
+                                .isInstanceOf(ForbiddenException.class)
+                                .hasMessageContaining("does not belong to this transaction");
+        }
+
+        @Test
+        void updateVisitor_withBlankName_throwsIllegalArgumentException() {
+                UUID transactionId = UUID.randomUUID();
+                UUID brokerId = UUID.randomUUID();
+                Transaction tx = createSellSideTransaction(transactionId, brokerId);
+
+                var visitor = createVisitorEntity(transactionId, "Original", null, null);
+
+                when(transactionRepository.findByTransactionId(transactionId)).thenReturn(Optional.of(tx));
+                when(visitorRepository.findByVisitorId(visitor.getVisitorId())).thenReturn(Optional.of(visitor));
+
+                var dto = new com.example.courtierprobackend.transactions.datalayer.dto.VisitorRequestDTO(
+                                "", null, null);
+
+                assertThatThrownBy(
+                                () -> transactionService.updateVisitor(transactionId, visitor.getVisitorId(), dto, brokerId))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("Visitor name is required");
+        }
+
+        @Test
+        void removeVisitor_withValidData_deletesVisitor() {
+                UUID transactionId = UUID.randomUUID();
+                UUID brokerId = UUID.randomUUID();
+                Transaction tx = createSellSideTransaction(transactionId, brokerId);
+
+                var visitor = createVisitorEntity(transactionId, "To Delete", "del@test.com", null);
+
+                when(transactionRepository.findByTransactionId(transactionId)).thenReturn(Optional.of(tx));
+                when(visitorRepository.findByVisitorId(visitor.getVisitorId())).thenReturn(Optional.of(visitor));
+
+                transactionService.removeVisitor(transactionId, visitor.getVisitorId(), brokerId);
+
+                verify(visitorRepository).delete(visitor);
+        }
+
+        @Test
+        void removeVisitor_withWrongTransaction_throwsForbiddenException() {
+                UUID transactionId = UUID.randomUUID();
+                UUID otherTransactionId = UUID.randomUUID();
+                UUID brokerId = UUID.randomUUID();
+                Transaction tx = createSellSideTransaction(transactionId, brokerId);
+
+                var visitor = createVisitorEntity(otherTransactionId, "Wrong Tx", null, null);
+
+                when(transactionRepository.findByTransactionId(transactionId)).thenReturn(Optional.of(tx));
+                when(visitorRepository.findByVisitorId(visitor.getVisitorId())).thenReturn(Optional.of(visitor));
+
+                assertThatThrownBy(
+                                () -> transactionService.removeVisitor(transactionId, visitor.getVisitorId(), brokerId))
+                                .isInstanceOf(ForbiddenException.class)
+                                .hasMessageContaining("does not belong to this transaction");
+        }
+
+        @Test
+        void removeVisitor_withNonExistentVisitor_throwsNotFoundException() {
+                UUID transactionId = UUID.randomUUID();
+                UUID brokerId = UUID.randomUUID();
+                Transaction tx = createSellSideTransaction(transactionId, brokerId);
+
+                when(transactionRepository.findByTransactionId(transactionId)).thenReturn(Optional.of(tx));
+                when(visitorRepository.findByVisitorId(any())).thenReturn(Optional.empty());
+
+                assertThatThrownBy(
+                                () -> transactionService.removeVisitor(transactionId, UUID.randomUUID(), brokerId))
+                                .isInstanceOf(NotFoundException.class)
+                                .hasMessageContaining("Visitor not found");
         }
 }

--- a/frontend/src/features/analytics/types.ts
+++ b/frontend/src/features/analytics/types.ts
@@ -15,9 +15,14 @@ export interface AnalyticsData {
     buyerStageDistribution: Record<string, number>;
     sellerStageDistribution: Record<string, number>;
 
-    // House Visits
+    // House Visits (Buy-Side)
     totalHouseVisits: number;
     avgHouseVisitsPerClosedTransaction: number;
+
+    // Showings (Sell-Side)
+    totalSellShowings: number;
+    avgSellShowingsPerClosedTransaction: number;
+    totalSellVisitors: number;
 
     // Properties (Buy-Side)
     totalProperties: number;

--- a/frontend/src/features/appointments/api/mutations.ts
+++ b/frontend/src/features/appointments/api/mutations.ts
@@ -83,8 +83,11 @@ export function useUpdateVisitorCount() {
             const res = await axiosInstance.patch(`/appointments/${appointmentId}/visitor-count`, { numberOfVisitors });
             return res.data;
         },
-        onSuccess: () => {
+        onSuccess: (data) => {
             queryClient.invalidateQueries({ queryKey: appointmentKeys.all });
+            if (data.transactionId) {
+                queryClient.invalidateQueries({ queryKey: ['transactions', 'detail', data.transactionId] });
+            }
         },
     });
 }

--- a/frontend/src/features/appointments/api/mutations.ts
+++ b/frontend/src/features/appointments/api/mutations.ts
@@ -11,6 +11,7 @@ export interface AppointmentRequestDTO {
     endTime: string; // ISO time HH:mm
     message: string;
     propertyId?: string; // Required for house_visit type
+    visitorId?: string; // Required for private_showing type
 }
 
 export function useRequestAppointment() {
@@ -70,6 +71,20 @@ export function useCancelAppointment() {
             if (data.transactionId) {
                 queryClient.invalidateQueries({ queryKey: ['transactions', 'detail', data.transactionId, 'timeline'] });
             }
+        },
+    });
+}
+
+export function useUpdateVisitorCount() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async ({ appointmentId, numberOfVisitors }: { appointmentId: string; numberOfVisitors: number }) => {
+            const res = await axiosInstance.patch(`/appointments/${appointmentId}/visitor-count`, { numberOfVisitors });
+            return res.data;
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: appointmentKeys.all });
         },
     });
 }

--- a/frontend/src/features/appointments/components/AppointmentDetailModal.tsx
+++ b/frontend/src/features/appointments/components/AppointmentDetailModal.tsx
@@ -510,7 +510,10 @@ export function AppointmentDetailModal({ isOpen, onClose, appointment, existingA
                                                 appointmentId: appointment.appointmentId,
                                                 numberOfVisitors: visitorCountValue,
                                             }, {
-                                                onSuccess: () => setEditingVisitorCount(false),
+                                                onSuccess: () => {
+                                                    toast.success(t('visitorCountUpdated'));
+                                                    setEditingVisitorCount(false);
+                                                },
                                             });
                                         }}
                                         disabled={updateVisitorCountMutation.isPending}

--- a/frontend/src/features/appointments/components/CreateAppointmentModal.tsx
+++ b/frontend/src/features/appointments/components/CreateAppointmentModal.tsx
@@ -401,10 +401,6 @@ export function CreateAppointmentModal({
       return;
     }
 
-    if (appointmentType === 'private_showing' && !selectedVisitorId) {
-      toast.error(t('visitorRequired'));
-      return;
-    }
 
     // Validation for time
     const [startHour, startMin] = startTime.split(':').map(Number);
@@ -766,17 +762,12 @@ export function CreateAppointmentModal({
                   <User className="w-4 h-4" />
                   {t('selectVisitor')}
                 </span>
-                <span
-                  className="text-destructive text-sm"
-                  aria-label="required"
-                >
-                  {t('required')}
-                </span>
               </label>
               <Select
                 value={selectedVisitorId}
                 onValueChange={(value) => {
                   if (value === '__create_new__') {
+                    setSelectedVisitorId('');
                     setShowNewVisitorForm(true);
                   } else {
                     setSelectedVisitorId(value);
@@ -784,7 +775,7 @@ export function CreateAppointmentModal({
                   }
                 }}
               >
-                <SelectTrigger id="visitor-select" className="w-full" aria-required="true">
+                <SelectTrigger id="visitor-select" className="w-full">
                   <SelectValue placeholder={t('selectVisitor')} />
                 </SelectTrigger>
                 <SelectContent>

--- a/frontend/src/features/appointments/types.ts
+++ b/frontend/src/features/appointments/types.ts
@@ -28,6 +28,8 @@ export interface Appointment {
     refusalReason?: string | null;
     cancellationReason?: string | null;
     cancelledBy?: string | null;
+    numberOfVisitors?: number | null;
+    visitorId?: string | null;
     createdAt: string;
     updatedAt: string;
 }

--- a/frontend/src/features/transactions/api/mutations.ts
+++ b/frontend/src/features/transactions/api/mutations.ts
@@ -573,3 +573,51 @@ export function useDeleteSearchCriteria() {
         },
     });
 }
+
+// ==================== VISITOR MUTATIONS ====================
+
+import type { VisitorRequestDTO } from '@/shared/api/types';
+import { visitorKeys } from '@/features/transactions/api/queries';
+
+export function useAddVisitor() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async ({ transactionId, data }: { transactionId: string; data: VisitorRequestDTO }) => {
+            const res = await axiosInstance.post(`/transactions/${transactionId}/visitors`, data);
+            return res.data;
+        },
+        onSuccess: (_data, variables) => {
+            queryClient.invalidateQueries({ queryKey: visitorKeys.byTransaction(variables.transactionId) });
+            queryClient.invalidateQueries({ queryKey: transactionKeys.detail(variables.transactionId) });
+        },
+    });
+}
+
+export function useUpdateVisitor() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async ({ transactionId, visitorId, data }: { transactionId: string; visitorId: string; data: VisitorRequestDTO }) => {
+            const res = await axiosInstance.put(`/transactions/${transactionId}/visitors/${visitorId}`, data);
+            return res.data;
+        },
+        onSuccess: (_data, variables) => {
+            queryClient.invalidateQueries({ queryKey: visitorKeys.byTransaction(variables.transactionId) });
+        },
+    });
+}
+
+export function useDeleteVisitor() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async ({ transactionId, visitorId }: { transactionId: string; visitorId: string }) => {
+            await axiosInstance.delete(`/transactions/${transactionId}/visitors/${visitorId}`);
+        },
+        onSuccess: (_data, variables) => {
+            queryClient.invalidateQueries({ queryKey: visitorKeys.byTransaction(variables.transactionId) });
+            queryClient.invalidateQueries({ queryKey: transactionKeys.detail(variables.transactionId) });
+        },
+    });
+}

--- a/frontend/src/features/transactions/api/queries.ts
+++ b/frontend/src/features/transactions/api/queries.ts
@@ -40,6 +40,8 @@ export interface Transaction {
     archived?: boolean;
     archivedAt?: string;
     houseVisitCount?: number;
+    totalShowings?: number;
+    totalVisitors?: number;
 }
 
 export function usePinnedTransactionIds() {
@@ -385,6 +387,25 @@ export function useSearchCriteria(transactionId: string) {
         queryKey: searchCriteriaKeys.byTransaction(transactionId),
         queryFn: async () => {
             const res = await axiosInstance.get<SearchCriteria | null>(`/transactions/${transactionId}/search-criteria`);
+            return res.data;
+        },
+        enabled: !!transactionId,
+    });
+}
+
+// ==================== VISITOR QUERIES ====================
+
+import type { Visitor } from '@/shared/api/types';
+
+export const visitorKeys = {
+    byTransaction: (transactionId: string) => [...transactionKeys.detail(transactionId), 'visitors'] as const,
+};
+
+export function useTransactionVisitors(transactionId: string) {
+    return useQuery({
+        queryKey: visitorKeys.byTransaction(transactionId),
+        queryFn: async () => {
+            const res = await axiosInstance.get<Visitor[]>(`/transactions/${transactionId}/visitors`);
             return res.data;
         },
         enabled: !!transactionId,

--- a/frontend/src/features/transactions/components/TransactionInfo.tsx
+++ b/frontend/src/features/transactions/components/TransactionInfo.tsx
@@ -79,6 +79,22 @@ export function TransactionInfo({ transaction, hideClientLabel = false, onClient
             <p className="text-sm font-medium text-foreground">{transaction.houseVisitCount}</p>
           </div>
         )}
+        {transaction.side === 'SELL_SIDE' && (
+          <div className="flex gap-4 mt-2">
+            {transaction.totalShowings != null && (
+              <div>
+                <p className="text-xs text-muted-foreground">{t('totalShowings')}</p>
+                <p className="text-sm font-medium text-foreground">{transaction.totalShowings}</p>
+              </div>
+            )}
+            {transaction.totalVisitors != null && (
+              <div>
+                <p className="text-xs text-muted-foreground">{t('totalVisitors')}</p>
+                <p className="text-sm font-medium text-foreground">{transaction.totalVisitors}</p>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </Section>
   );

--- a/frontend/src/features/transactions/components/TransactionTabs.tsx
+++ b/frontend/src/features/transactions/components/TransactionTabs.tsx
@@ -14,6 +14,7 @@ import { TransactionTimeline } from './TransactionTimeline';
 import { PropertyList } from './PropertyList';
 import { OfferList } from './OfferList';
 import { ParticipantsList } from './ParticipantsList';
+import { VisitorList } from './VisitorList';
 import { ConditionList } from './ConditionList';
 import { AddConditionModal } from './AddConditionModal';
 import { ConditionDetailModal } from './ConditionDetailModal';
@@ -281,6 +282,12 @@ export function TransactionTabs({
             transactionId={transaction.transactionId}
             isReadOnly={isReadOnly}
           />
+          {transaction.side === 'SELL_SIDE' && (
+            <VisitorList
+              transactionId={transaction.transactionId}
+              isBroker={!isReadOnly}
+            />
+          )}
         </TabsContent>
       )}
 

--- a/frontend/src/features/transactions/components/VisitorList.tsx
+++ b/frontend/src/features/transactions/components/VisitorList.tsx
@@ -117,21 +117,21 @@ export function VisitorList({ transactionId, isBroker }: VisitorListProps) {
                 />
             </div>
             <div>
-                <label className="text-sm text-muted-foreground block mb-1">Email</label>
+                <label className="text-sm text-muted-foreground block mb-1">{t('visitorEmail')}</label>
                 <Input
                     type="email"
                     value={formEmail}
                     onChange={(e) => setFormEmail(e.target.value)}
-                    placeholder="Email"
+                    placeholder={t('visitorEmail')}
                 />
             </div>
             <div>
-                <label className="text-sm text-muted-foreground block mb-1">{t('phone', 'Phone')}</label>
+                <label className="text-sm text-muted-foreground block mb-1">{t('visitorPhone')}</label>
                 <Input
                     type="tel"
                     value={formPhone}
                     onChange={(e) => setFormPhone(e.target.value)}
-                    placeholder={t('phone', 'Phone')}
+                    placeholder={t('visitorPhone')}
                 />
             </div>
         </div>

--- a/frontend/src/features/transactions/components/VisitorList.tsx
+++ b/frontend/src/features/transactions/components/VisitorList.tsx
@@ -1,0 +1,264 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Trash2, Mail, Phone, Pencil, Plus, Users } from 'lucide-react';
+import { Button } from "@/shared/components/ui/button";
+import { Input } from "@/shared/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/shared/components/ui/card";
+import { Badge } from "@/shared/components/ui/badge";
+import { useTransactionVisitors } from '@/features/transactions/api/queries';
+import { useAddVisitor, useUpdateVisitor, useDeleteVisitor } from '@/features/transactions/api/mutations';
+import { toast } from 'sonner';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/shared/components/ui/dialog";
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from "@/shared/components/ui/alert-dialog";
+import type { Visitor, VisitorRequestDTO } from '@/shared/api/types';
+
+interface VisitorListProps {
+    transactionId: string;
+    isBroker: boolean;
+}
+
+export function VisitorList({ transactionId, isBroker }: VisitorListProps) {
+    const { t } = useTranslation('transactions');
+    const { data: visitors = [], isLoading } = useTransactionVisitors(transactionId);
+    const addVisitor = useAddVisitor();
+    const updateVisitor = useUpdateVisitor();
+    const deleteVisitor = useDeleteVisitor();
+
+    const [isAddOpen, setIsAddOpen] = useState(false);
+    const [editingVisitor, setEditingVisitor] = useState<Visitor | null>(null);
+    const [visitorToDelete, setVisitorToDelete] = useState<string | null>(null);
+
+    const [formName, setFormName] = useState('');
+    const [formEmail, setFormEmail] = useState('');
+    const [formPhone, setFormPhone] = useState('');
+
+    const resetForm = () => {
+        setFormName('');
+        setFormEmail('');
+        setFormPhone('');
+    };
+
+    const openAdd = () => {
+        resetForm();
+        setIsAddOpen(true);
+    };
+
+    const openEdit = (visitor: Visitor) => {
+        setFormName(visitor.name);
+        setFormEmail(visitor.email || '');
+        setFormPhone(visitor.phoneNumber || '');
+        setEditingVisitor(visitor);
+    };
+
+    const handleAdd = () => {
+        if (!formName.trim()) return;
+        const data: VisitorRequestDTO = {
+            name: formName.trim(),
+            email: formEmail.trim() || undefined,
+            phoneNumber: formPhone.trim() || undefined,
+        };
+        addVisitor.mutate({ transactionId, data }, {
+            onSuccess: () => {
+                toast.success(t('visitorAdded'));
+                setIsAddOpen(false);
+                resetForm();
+            },
+        });
+    };
+
+    const handleUpdate = () => {
+        if (!editingVisitor || !formName.trim()) return;
+        const data: VisitorRequestDTO = {
+            name: formName.trim(),
+            email: formEmail.trim() || undefined,
+            phoneNumber: formPhone.trim() || undefined,
+        };
+        updateVisitor.mutate({ transactionId, visitorId: editingVisitor.visitorId, data }, {
+            onSuccess: () => {
+                toast.success(t('visitorUpdated'));
+                setEditingVisitor(null);
+                resetForm();
+            },
+        });
+    };
+
+    const handleDelete = () => {
+        if (!visitorToDelete) return;
+        deleteVisitor.mutate({ transactionId, visitorId: visitorToDelete }, {
+            onSuccess: () => {
+                toast.success(t('visitorDeleted'));
+                setVisitorToDelete(null);
+            },
+        });
+    };
+
+    if (isLoading) {
+        return <div className="animate-pulse h-24 bg-muted rounded-md" />;
+    }
+
+    const visitorForm = (
+        <div className="space-y-3">
+            <div>
+                <label className="text-sm text-muted-foreground block mb-1">{t('visitorName')}</label>
+                <Input
+                    value={formName}
+                    onChange={(e) => setFormName(e.target.value)}
+                    placeholder={t('visitorName')}
+                    autoFocus
+                />
+            </div>
+            <div>
+                <label className="text-sm text-muted-foreground block mb-1">Email</label>
+                <Input
+                    type="email"
+                    value={formEmail}
+                    onChange={(e) => setFormEmail(e.target.value)}
+                    placeholder="Email"
+                />
+            </div>
+            <div>
+                <label className="text-sm text-muted-foreground block mb-1">{t('phone', 'Phone')}</label>
+                <Input
+                    type="tel"
+                    value={formPhone}
+                    onChange={(e) => setFormPhone(e.target.value)}
+                    placeholder={t('phone', 'Phone')}
+                />
+            </div>
+        </div>
+    );
+
+    return (
+        <>
+            <Card className="mt-4">
+                <CardHeader className="flex flex-row items-center justify-between py-4">
+                    <CardTitle className="text-lg font-medium flex items-center gap-2">
+                        <Users className="h-5 w-5" />
+                        {t('visitors')}
+                    </CardTitle>
+                    {isBroker && (
+                        <Button size="sm" onClick={openAdd} className="gap-2">
+                            <Plus className="h-4 w-4" />
+                            {t('addVisitor')}
+                        </Button>
+                    )}
+                </CardHeader>
+                <CardContent>
+                    {visitors.length === 0 ? (
+                        <div className="text-center py-6 text-muted-foreground">
+                            {t('noVisitors')}
+                        </div>
+                    ) : (
+                        <div className="space-y-3">
+                            {visitors.map((visitor) => (
+                                <div key={visitor.visitorId} className="flex items-start justify-between p-3 border rounded-lg bg-card">
+                                    <div className="space-y-1">
+                                        <div className="flex items-center gap-2">
+                                            <span className="font-medium">{visitor.name}</span>
+                                            <Badge variant="secondary" className="text-xs">
+                                                {t('timesVisited', { count: visitor.timesVisited })}
+                                            </Badge>
+                                        </div>
+                                        <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+                                            {visitor.email && (
+                                                <div className="flex items-center gap-1">
+                                                    <Mail className="h-3 w-3" />
+                                                    <span>{visitor.email}</span>
+                                                </div>
+                                            )}
+                                            {visitor.phoneNumber && (
+                                                <div className="flex items-center gap-1">
+                                                    <Phone className="h-3 w-3" />
+                                                    <span>{visitor.phoneNumber}</span>
+                                                </div>
+                                            )}
+                                        </div>
+                                    </div>
+                                    {isBroker && (
+                                        <div className="flex gap-2">
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                className="text-muted-foreground hover:text-primary"
+                                                onClick={() => openEdit(visitor)}
+                                            >
+                                                <Pencil className="h-4 w-4" />
+                                            </Button>
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                className="text-muted-foreground hover:text-destructive"
+                                                onClick={() => setVisitorToDelete(visitor.visitorId)}
+                                            >
+                                                <Trash2 className="h-4 w-4" />
+                                            </Button>
+                                        </div>
+                                    )}
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+
+            {/* Add Visitor Modal */}
+            <Dialog open={isAddOpen} onOpenChange={(val) => !val && setIsAddOpen(false)}>
+                <DialogContent className="sm:max-w-md">
+                    <DialogHeader>
+                        <DialogTitle>{t('addVisitor')}</DialogTitle>
+                    </DialogHeader>
+                    {visitorForm}
+                    <div className="flex gap-2 justify-end pt-2">
+                        <Button variant="ghost" onClick={() => setIsAddOpen(false)}>{t('cancel')}</Button>
+                        <Button onClick={handleAdd} disabled={!formName.trim() || addVisitor.isPending}>
+                            {t('addVisitor')}
+                        </Button>
+                    </div>
+                </DialogContent>
+            </Dialog>
+
+            {/* Edit Visitor Modal */}
+            <Dialog open={!!editingVisitor} onOpenChange={(val) => !val && setEditingVisitor(null)}>
+                <DialogContent className="sm:max-w-md">
+                    <DialogHeader>
+                        <DialogTitle>{t('editVisitor')}</DialogTitle>
+                    </DialogHeader>
+                    {visitorForm}
+                    <div className="flex gap-2 justify-end pt-2">
+                        <Button variant="ghost" onClick={() => setEditingVisitor(null)}>{t('cancel')}</Button>
+                        <Button onClick={handleUpdate} disabled={!formName.trim() || updateVisitor.isPending}>
+                            {t('editVisitor')}
+                        </Button>
+                    </div>
+                </DialogContent>
+            </Dialog>
+
+            {/* Delete Confirmation */}
+            <AlertDialog open={!!visitorToDelete} onOpenChange={(open) => !open && setVisitorToDelete(null)}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>{t('deleteVisitor')}</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            {t('confirmDeleteVisitor')}
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>{t('cancel')}</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleDelete} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+                            {t('deleteVisitor')}
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </>
+    );
+}

--- a/frontend/src/pages/analytics/AnalyticsPage.tsx
+++ b/frontend/src/pages/analytics/AnalyticsPage.tsx
@@ -198,13 +198,23 @@ export function AnalyticsPage() {
         )}
       </div>
 
-      {/* ─── HOUSE VISITS ─── */}
-      <Section title={t("sections.houseVisits")}>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <KpiCard title={t("stats.totalHouseVisits")} value={data.totalHouseVisits} icon={<Building2 className="h-5 w-5" />} />
-          <KpiCard title={t("stats.avgHouseVisits")} value={data.avgHouseVisitsPerClosedTransaction} icon={<TrendingUp className="h-5 w-5" />} />
-        </div>
-      </Section>
+      {/* ─── HOUSE VISITS + SELL SHOWINGS ─── */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Section title={t("sections.houseVisits")}>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <KpiCard title={t("stats.totalHouseVisits")} value={data.totalHouseVisits} icon={<Building2 className="h-5 w-5" />} />
+            <KpiCard title={t("stats.avgHouseVisits")} value={data.avgHouseVisitsPerClosedTransaction} icon={<TrendingUp className="h-5 w-5" />} />
+          </div>
+        </Section>
+
+        <Section title={t("sections.sellShowings")}>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <KpiCard title={t("stats.totalSellShowings")} value={data.totalSellShowings} icon={<Eye className="h-5 w-5" />} />
+            <KpiCard title={t("stats.avgSellShowingsPerClosedTransaction")} value={data.avgSellShowingsPerClosedTransaction} icon={<TrendingUp className="h-5 w-5" />} />
+            <KpiCard title={t("stats.totalSellVisitors")} value={data.totalSellVisitors} icon={<Users className="h-5 w-5" />} />
+          </div>
+        </Section>
+      </div>
 
       {/* ─── PROPERTIES + BUYER OFFERS (side by side) ─── */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/frontend/src/shared/api/types.ts
+++ b/frontend/src/shared/api/types.ts
@@ -519,3 +519,22 @@ export interface SearchCriteriaRequestDTO {
   maxPrice?: number;
   regions?: QuebecRegion[];
 }
+
+// ==================== VISITOR TYPES (for sell-side transactions) ====================
+
+export interface Visitor {
+  visitorId: string;
+  transactionId: string;
+  name: string;
+  email?: string;
+  phoneNumber?: string;
+  timesVisited: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface VisitorRequestDTO {
+  name: string;
+  email?: string;
+  phoneNumber?: string;
+}

--- a/frontend/src/shared/i18n/en/analytics.json
+++ b/frontend/src/shared/i18n/en/analytics.json
@@ -17,7 +17,8 @@
         "clientEngagement": "Client Engagement",
         "trends": "Trends",
         "activity": "Activity Summary",
-        "monthlyActivity": "Monthly Activity"
+        "monthlyActivity": "Monthly Activity",
+        "sellShowings": "Sell-Side Showings"
     },
     "stats": {
         "totalTransactions": "Total Transactions",
@@ -75,7 +76,10 @@
         "busiestMonth": "Busiest Month",
         "idleTransactions": "Idle Transactions (30+ days)",
         "opened": "Opened",
-        "closed": "Closed"
+        "closed": "Closed",
+        "totalSellShowings": "Total Showings",
+        "avgSellShowingsPerClosedTransaction": "Avg. per Closed Sell",
+        "totalSellVisitors": "Total Visitors"
     },
     "stageLabels": {
         "buyerStages": "Buyer Stages",

--- a/frontend/src/shared/i18n/en/appointments.json
+++ b/frontend/src/shared/i18n/en/appointments.json
@@ -107,5 +107,21 @@
     "appointmentDeclined": "Appointment declined",
     "appointmentCancelledSuccess": "Appointment cancelled",
     "appointmentRescheduled": "New time proposal sent",
-    "errorActionFailed": "An error occurred while processing your request"
+    "errorActionFailed": "An error occurred while processing your request",
+    "open_house": "Open House",
+    "private_showing": "Private Showing",
+    "numberOfVisitors": "Number of Visitors",
+    "selectVisitor": "Select Visitor",
+    "createNewVisitor": "Create New Visitor",
+    "visitorRequired": "A visitor must be selected for private showings",
+    "eventNotConcluded": "Visitor count can be updated after the event concludes",
+    "updateVisitorCount": "Update Visitor Count",
+    "visitorCountUpdated": "Visitor count updated successfully",
+    "visitorName": "Visitor Name",
+    "visitorEmail": "Email",
+    "visitorPhone": "Phone",
+    "visitorNameRequired": "Visitor name is required",
+    "visitorCreated": "Visitor created successfully",
+    "saveVisitor": "Save Visitor",
+    "cancelCreateVisitor": "Cancel"
 }

--- a/frontend/src/shared/i18n/en/transactions.json
+++ b/frontend/src/shared/i18n/en/transactions.json
@@ -315,6 +315,8 @@
     "inspection": "Inspection",
     "walkthrough": "Walkthrough",
     "appraisal": "Appraisal",
+    "open_house": "Open House",
+    "private_showing": "Private Showing",
     "other": "Other"
   },
   "setActive": "Set Active",
@@ -795,5 +797,19 @@
       "MONTEREGIE": "Montérégie",
       "CENTRE_DU_QUEBEC": "Centre-du-Québec"
     }
-  }
+  },
+  "totalShowings": "Total Showings",
+  "totalVisitors": "Total Visitors",
+  "visitors": "Visitors",
+  "addVisitor": "Add Visitor",
+  "editVisitor": "Edit Visitor",
+  "deleteVisitor": "Delete Visitor",
+  "visitorName": "Visitor Name",
+  "timesVisited": "{{count}} visit",
+  "timesVisited_other": "{{count}} visits",
+  "noVisitors": "No visitors yet",
+  "visitorAdded": "Visitor added successfully",
+  "visitorUpdated": "Visitor updated successfully",
+  "visitorDeleted": "Visitor deleted successfully",
+  "confirmDeleteVisitor": "Are you sure you want to delete this visitor?"
 }

--- a/frontend/src/shared/i18n/en/transactions.json
+++ b/frontend/src/shared/i18n/en/transactions.json
@@ -805,6 +805,8 @@
   "editVisitor": "Edit Visitor",
   "deleteVisitor": "Delete Visitor",
   "visitorName": "Visitor Name",
+  "visitorEmail": "Visitor Email",
+  "visitorPhone": "Visitor Phone",
   "timesVisited": "{{count}} visit",
   "timesVisited_other": "{{count}} visits",
   "noVisitors": "No visitors yet",

--- a/frontend/src/shared/i18n/fr/analytics.json
+++ b/frontend/src/shared/i18n/fr/analytics.json
@@ -17,7 +17,8 @@
         "clientEngagement": "Engagement client",
         "trends": "Tendances",
         "activity": "Résumé d'activité",
-        "monthlyActivity": "Activité mensuelle"
+        "monthlyActivity": "Activité mensuelle",
+        "sellShowings": "Visites de vente"
     },
     "stats": {
         "totalTransactions": "Total des transactions",
@@ -75,7 +76,10 @@
         "busiestMonth": "Mois le plus chargé",
         "idleTransactions": "Transactions inactives (30+ jours)",
         "opened": "Ouvertes",
-        "closed": "Fermées"
+        "closed": "Fermées",
+        "totalSellShowings": "Total des visites",
+        "avgSellShowingsPerClosedTransaction": "Moy. par vente fermée",
+        "totalSellVisitors": "Total des visiteurs"
     },
     "stageLabels": {
         "buyerStages": "Étapes de l'acheteur",

--- a/frontend/src/shared/i18n/fr/appointments.json
+++ b/frontend/src/shared/i18n/fr/appointments.json
@@ -107,5 +107,21 @@
     "appointmentDeclined": "Rendez-vous refusé.",
     "appointmentCancelledSuccess": "Rendez-vous annulé.",
     "appointmentRescheduled": "Rendez-vous replanifié avec succès.",
-    "errorActionFailed": "L'action a échoué. Veuillez réessayer."
+    "errorActionFailed": "L'action a échoué. Veuillez réessayer.",
+    "open_house": "Portes ouvertes",
+    "private_showing": "Visite privée",
+    "numberOfVisitors": "Nombre de visiteurs",
+    "selectVisitor": "Sélectionner un visiteur",
+    "createNewVisitor": "Créer un nouveau visiteur",
+    "visitorRequired": "Un visiteur doit être sélectionné pour les visites privées",
+    "eventNotConcluded": "Le nombre de visiteurs peut être mis à jour après la fin de l'événement",
+    "updateVisitorCount": "Mettre à jour le nombre de visiteurs",
+    "visitorCountUpdated": "Nombre de visiteurs mis à jour avec succès",
+    "visitorName": "Nom du visiteur",
+    "visitorEmail": "Courriel",
+    "visitorPhone": "Téléphone",
+    "visitorNameRequired": "Le nom du visiteur est requis",
+    "visitorCreated": "Visiteur créé avec succès",
+    "saveVisitor": "Enregistrer le visiteur",
+    "cancelCreateVisitor": "Annuler"
 }

--- a/frontend/src/shared/i18n/fr/transactions.json
+++ b/frontend/src/shared/i18n/fr/transactions.json
@@ -496,6 +496,8 @@
     "inspection": "Inspection",
     "walkthrough": "Visite des lieux",
     "appraisal": "Évaluation",
+    "open_house": "Portes ouvertes",
+    "private_showing": "Visite privée",
     "other": "Autre"
   },
   "setActive": "Définir actif",
@@ -787,5 +789,19 @@
       "MONTEREGIE": "Montérégie",
       "CENTRE_DU_QUEBEC": "Centre-du-Québec"
     }
-  }
+  },
+  "totalShowings": "Total des visites",
+  "totalVisitors": "Total des visiteurs",
+  "visitors": "Visiteurs",
+  "addVisitor": "Ajouter un visiteur",
+  "editVisitor": "Modifier le visiteur",
+  "deleteVisitor": "Supprimer le visiteur",
+  "visitorName": "Nom du visiteur",
+  "timesVisited": "{{count}} visite",
+  "timesVisited_other": "{{count}} visites",
+  "noVisitors": "Aucun visiteur pour le moment",
+  "visitorAdded": "Visiteur ajouté avec succès",
+  "visitorUpdated": "Visiteur mis à jour avec succès",
+  "visitorDeleted": "Visiteur supprimé avec succès",
+  "confirmDeleteVisitor": "Êtes-vous sûr de vouloir supprimer ce visiteur ?"
 }

--- a/frontend/src/shared/i18n/fr/transactions.json
+++ b/frontend/src/shared/i18n/fr/transactions.json
@@ -797,6 +797,8 @@
   "editVisitor": "Modifier le visiteur",
   "deleteVisitor": "Supprimer le visiteur",
   "visitorName": "Nom du visiteur",
+  "visitorEmail": "Courriel du visiteur",
+  "visitorPhone": "Téléphone du visiteur",
   "timesVisited": "{{count}} visite",
   "timesVisited_other": "{{count}} visites",
   "noVisitors": "Aucun visiteur pour le moment",


### PR DESCRIPTION
This pull request introduces significant enhancements to the appointment and analytics features, mainly focusing on tracking visitor counts for open house and private showing appointments, and improving analytics for sell-side showings. It also adds new API endpoints, DTO fields, data model attributes, and repository queries to support these features.

**Appointment Visitor Tracking and Validation:**

- Added `numberOfVisitors` and `visitorId` fields to the `Appointment` entity, DTOs (`AppointmentRequestDTO`, `AppointmentResponseDTO`), and associated getter/setter methods, enabling tracking of visitors for open house and private showing appointments. [[1]](diffhunk://#diff-ead42722274038d7edddb52fd7ab7fea19107156a07add25b49e761b9fbc492fR96-R101) [[2]](diffhunk://#diff-ead42722274038d7edddb52fd7ab7fea19107156a07add25b49e761b9fbc492fR342-R357) [[3]](diffhunk://#diff-c795030eeab4a105412f1dadbccf950888e1a0ce1fe7d2418e4cf05d5564ac38L15-R16) [[4]](diffhunk://#diff-5d3ea11b1ff9d39d3b81c0ec53f992642211f2257cc8ba3af322c3109761cf0cL33-R35)
- Implemented validation in `AppointmentServiceImpl` to ensure open house and private showing appointments can only be created for sell-side transactions, and that private showings default to one visitor unless a specific visitor is provided and validated.

**API and Service Layer Enhancements:**

- Added a new endpoint (`PATCH /appointments/{appointmentId}/visitor-count`) and service method to allow brokers to update the visitor count for open house or private showing appointments, with proper authorization and business rule checks (e.g., open house visitor count can only be set after the event concludes). [[1]](diffhunk://#diff-88ea6c2cc6fecdeab2625a358636fea87c29d1a3f7e18ec608ae60329a505086R205-R225) [[2]](diffhunk://#diff-9c4f511afbda5902046230c906bf4ce753c59b81bdcf2ae7745afecf2881e7cbR113-R117) [[3]](diffhunk://#diff-06d5a99d78cc1be3886ac3735fe5628f76ab7de9d0843df03c0de39e9432ec02R755-R785)
- Updated the mapping logic to include the new visitor-related fields in appointment responses.

**Analytics and Reporting Improvements:**

- Enhanced analytics to track and report total sell-side showings, average showings per closed sell transaction, and total sell-side visitors, using efficient aggregation from appointments. These new metrics are included in the `AnalyticsDTO` and calculated in `AnalyticsService`. [[1]](diffhunk://#diff-7be259243663337d3da297afe15f61d347de2d2d9cd6a5e0f9d3a7df5364410eL25-R33) [[2]](diffhunk://#diff-fb8105f401e2f4c6807420141164e3f124dfc03f1d68317b6c73e2e8b5b1da78R121-R155) [[3]](diffhunk://#diff-fb8105f401e2f4c6807420141164e3f124dfc03f1d68317b6c73e2e8b5b1da78R349)
- Optimized analytics by loading all appointments once for reuse across analytics calculations. [[1]](diffhunk://#diff-fb8105f401e2f4c6807420141164e3f124dfc03f1d68317b6c73e2e8b5b1da78R40-R43) [[2]](diffhunk://#diff-fb8105f401e2f4c6807420141164e3f124dfc03f1d68317b6c73e2e8b5b1da78L236-L237)

**Repository and Data Access Layer:**

- Added new queries to `AppointmentRepository` for counting confirmed showings and summing visitors, both per transaction and per visitor, supporting efficient analytics and reporting.

**Dependency Injection and Wiring:**

- Injected `VisitorRepository` into `AppointmentServiceImpl` to support visitor validation when creating private showings. [[1]](diffhunk://#diff-06d5a99d78cc1be3886ac3735fe5628f76ab7de9d0843df03c0de39e9432ec02R62) [[2]](diffhunk://#diff-06d5a99d78cc1be3886ac3735fe5628f76ab7de9d0843df03c0de39e9432ec02L71-R73) [[3]](diffhunk://#diff-06d5a99d78cc1be3886ac3735fe5628f76ab7de9d0843df03c0de39e9432ec02R83)

These changes collectively improve the system's ability to track, validate, and report on visitor activity for sell-side appointments, providing more granular analytics and enforcing important business rules.